### PR TITLE
Feature: 'Offer to collect' action on Swarm List

### DIFF
--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -462,7 +462,8 @@ func TestPrepareSwarmHandler_ValidRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := writer.Close(); err != nil {
-t.Errorf("Error closing writer: %v", err)	}
+		t.Errorf("Error closing writer: %v", err)
+	}
 
 	req, err := http.NewRequest("POST", "/prepare_swarm", body)
 	if err != nil {
@@ -566,7 +567,8 @@ func TestConfirmSwarmHandler_ValidRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := writer.Close(); err != nil {
-t.Errorf("Error closing writer: %v", err)	}
+		t.Errorf("Error closing writer: %v", err)
+	}
 
 	req, err := http.NewRequest("POST", "/confirm_swarm", body)
 	if err != nil {

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -177,6 +177,9 @@ func (m *MockStore) UpdateSwarm(_ context.Context, swarmID string, updates []fir
 				if update.Path == "assignedCollectorID" {
 					m.Swarms[i].AssignedCollectorID = update.Value.(string)
 				}
+				if update.Path == "assignedCollectorEmail" {
+					m.Swarms[i].AssignedCollectorEmail = update.Value.(string)
+				}
 			}
 			return nil
 		}
@@ -870,7 +873,7 @@ func TestAssignSwarmHandler(t *testing.T) {
 			{ID: "test-swarm-id"},
 		},
 		Sessions: map[string]models.Session{
-			"test-session-id": {UserID: "test-user", Role: "collector", ExpiresAt: time.Now().Add(1 * time.Hour)},
+			"test-session-id": {UserID: "test-user", Username: "test@example.com", Role: "collector", ExpiresAt: time.Now().Add(1 * time.Hour)},
 		},
 	}
 	h := &Handlers{Store: mockStore}
@@ -894,6 +897,48 @@ func TestAssignSwarmHandler(t *testing.T) {
 
 	if mockStore.Swarms[0].AssignedCollectorID != "test-user" {
 		t.Error("expected swarm to be assigned to the user")
+	}
+	if mockStore.Swarms[0].AssignedCollectorEmail != "test@example.com" {
+		t.Error("expected swarm to be assigned to the user email")
+	}
+}
+
+func TestClaimSwarmHandler(t *testing.T) {
+	mockStore := &MockStore{
+		Swarms: []models.SwarmReport{
+			{ID: "test-swarm-id", Status: "Reported"},
+		},
+		Sessions: map[string]models.Session{
+			"test-session-id": {UserID: "test-user", Username: "test@example.com", Role: "collector", ExpiresAt: time.Now().Add(1 * time.Hour)},
+		},
+	}
+	h := &Handlers{Store: mockStore}
+
+	body := strings.NewReader("swarmID=test-swarm-id")
+	req, err := http.NewRequest("POST", "/claim_swarm", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "session", Value: "test-session-id"})
+
+	rr := httptest.NewRecorder()
+	handler := h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.ClaimSwarmHandler)))
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusSeeOther {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusSeeOther)
+	}
+
+	if mockStore.Swarms[0].AssignedCollectorID != "test-user" {
+		t.Error("expected swarm to be assigned to the user ID")
+	}
+	if mockStore.Swarms[0].AssignedCollectorEmail != "test@example.com" {
+		t.Error("expected swarm to be assigned to the user email")
+	}
+	if mockStore.Swarms[0].Status != "Collection in Progress" {
+		t.Errorf("expected swarm status to be 'Collection in Progress', got '%s'", mockStore.Swarms[0].Status)
 	}
 }
 

--- a/backend/handlers/swarm.go
+++ b/backend/handlers/swarm.go
@@ -333,6 +333,7 @@ func (h *Handlers) ClaimSwarmHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // Limit body to 1MB
 	session, ok := r.Context().Value(SessionContextKey).(*models.Session)
 	if !ok {
 		http.Error(w, "Could not retrieve session from context", http.StatusInternalServerError)

--- a/backend/handlers/swarm.go
+++ b/backend/handlers/swarm.go
@@ -312,8 +312,10 @@ func (h *Handlers) AssignSwarmHandler(w http.ResponseWriter, r *http.Request) {
 	switch action {
 	case "assign":
 		updates = append(updates, firestore.Update{Path: "assignedCollectorID", Value: session.UserID})
+		updates = append(updates, firestore.Update{Path: "assignedCollectorEmail", Value: session.Username})
 	case "unassign":
 		updates = append(updates, firestore.Update{Path: "assignedCollectorID", Value: ""})
+		updates = append(updates, firestore.Update{Path: "assignedCollectorEmail", Value: ""})
 	}
 	updates = append(updates, firestore.Update{Path: "lastUpdatedTimestamp", Value: time.Now()})
 
@@ -323,6 +325,38 @@ func (h *Handlers) AssignSwarmHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+}
+
+func (h *Handlers) ClaimSwarmHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	session, ok := r.Context().Value(SessionContextKey).(*models.Session)
+	if !ok {
+		http.Error(w, "Could not retrieve session from context", http.StatusInternalServerError)
+		return
+	}
+
+	swarmID := r.FormValue("swarmID")
+	if swarmID == "" {
+		http.Error(w, "Swarm ID required", http.StatusBadRequest)
+		return
+	}
+
+	var updates []firestore.Update
+	updates = append(updates, firestore.Update{Path: "assignedCollectorID", Value: session.UserID})
+	updates = append(updates, firestore.Update{Path: "assignedCollectorEmail", Value: session.Username})
+	updates = append(updates, firestore.Update{Path: "status", Value: "Collection in Progress"})
+	updates = append(updates, firestore.Update{Path: "lastUpdatedTimestamp", Value: time.Now()})
+
+	if err := h.Store.UpdateSwarm(r.Context(), swarmID, updates); err != nil {
+		http.Error(w, "Failed to update swarm", http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/swarmlist", http.StatusSeeOther)
 }
 
 func validateFile(file *multipart.FileHeader) error {

--- a/backend/handlers/views.go
+++ b/backend/handlers/views.go
@@ -20,6 +20,14 @@ func (h *Handlers) SwarmListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Dynamic DisplayStatus logic
+	for i := range swarms {
+		swarms[i].DisplayStatus = swarms[i].Status
+		if swarms[i].Status != "Captured" && time.Since(swarms[i].ReportedTimestamp).Hours() > 24 {
+			swarms[i].DisplayStatus = "Archived"
+		}
+	}
+
 	err = h.Templates.ExecuteTemplate(w, "swarmlist.html", map[string]interface{}{
 		"Title":             "Swarm List",
 		"Swarms":            swarms,

--- a/backend/handlers/views.go
+++ b/backend/handlers/views.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/fkcurrie/utba-swarmmap/models"
 )

--- a/backend/main.go
+++ b/backend/main.go
@@ -130,6 +130,7 @@ func main() {
 	mux.Handle("GET /collector_admin", h.RequireAuth(h.RequireRole("collector_admin", http.HandlerFunc(h.CollectorAdminHandler))))
 	mux.Handle("POST /update_swarm_status", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.UpdateSwarmStatusHandler))))
 	mux.Handle("POST /assign_swarm", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.AssignSwarmHandler))))
+	mux.Handle("POST /claim_swarm", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.ClaimSwarmHandler))))
 	// Add other routes here as they are refactored
 
 	port := getEnv("PORT", "8080")

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -19,6 +19,7 @@ type SwarmReport struct {
 	DisplayStatus         string    `firestore:"-" json:"displayStatus,omitempty"` // Transient, for frontend logic
 	NearestIntersection   string    `firestore:"nearestIntersection,omitempty" json:"nearestIntersection,omitempty"`
 	AssignedCollectorID   string    `firestore:"assignedCollectorID,omitempty" json:"assignedCollectorID,omitempty"`
+	AssignedCollectorEmail string    `firestore:"assignedCollectorEmail,omitempty" json:"assignedCollectorEmail,omitempty"`
 	// Contact information for public reporters
 	ReporterName      string `firestore:"reporterName,omitempty" json:"reporterName,omitempty"`
 	ReporterEmail     string `firestore:"reporterEmail,omitempty" json:"reporterEmail,omitempty"`

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -4,21 +4,21 @@ import "time"
 
 // SwarmReport defines the structure for a swarm report (matches Firestore document)
 type SwarmReport struct {
-	ID                    string    `firestore:"-" json:"id"` // Firestore doc ID, not stored in doc fields
-	Latitude              float64   `firestore:"latitude" json:"latitude"`
-	Longitude             float64   `firestore:"longitude" json:"longitude"`
-	Description           string    `firestore:"description" json:"description"`
-	Status                string    `firestore:"status" json:"status"`
-	ReportedTimestamp     time.Time `firestore:"reportedTimestamp" json:"reportedTimestamp"`
-	VerificationTimestamp time.Time `firestore:"verificationTimestamp,omitempty" json:"verificationTimestamp,omitempty"`
-	CapturedTimestamp     time.Time `firestore:"capturedTimestamp,omitempty" json:"capturedTimestamp,omitempty"`
-	LastUpdatedTimestamp  time.Time `firestore:"lastUpdatedTimestamp" json:"lastUpdatedTimestamp"`
-	ReportedMediaURLs     []string  `firestore:"reportedMediaURLs,omitempty" json:"reportedMediaURLs,omitempty"`
-	CapturedMediaURLs     []string  `firestore:"capturedMediaURLs,omitempty" json:"capturedMediaURLs,omitempty"`
-	BeekeeperNotes        string    `firestore:"beekeeperNotes,omitempty" json:"beekeeperNotes,omitempty"`
-	DisplayStatus         string    `firestore:"-" json:"displayStatus,omitempty"` // Transient, for frontend logic
-	NearestIntersection   string    `firestore:"nearestIntersection,omitempty" json:"nearestIntersection,omitempty"`
-	AssignedCollectorID   string    `firestore:"assignedCollectorID,omitempty" json:"assignedCollectorID,omitempty"`
+	ID                     string    `firestore:"-" json:"id"` // Firestore doc ID, not stored in doc fields
+	Latitude               float64   `firestore:"latitude" json:"latitude"`
+	Longitude              float64   `firestore:"longitude" json:"longitude"`
+	Description            string    `firestore:"description" json:"description"`
+	Status                 string    `firestore:"status" json:"status"`
+	ReportedTimestamp      time.Time `firestore:"reportedTimestamp" json:"reportedTimestamp"`
+	VerificationTimestamp  time.Time `firestore:"verificationTimestamp,omitempty" json:"verificationTimestamp,omitempty"`
+	CapturedTimestamp      time.Time `firestore:"capturedTimestamp,omitempty" json:"capturedTimestamp,omitempty"`
+	LastUpdatedTimestamp   time.Time `firestore:"lastUpdatedTimestamp" json:"lastUpdatedTimestamp"`
+	ReportedMediaURLs      []string  `firestore:"reportedMediaURLs,omitempty" json:"reportedMediaURLs,omitempty"`
+	CapturedMediaURLs      []string  `firestore:"capturedMediaURLs,omitempty" json:"capturedMediaURLs,omitempty"`
+	BeekeeperNotes         string    `firestore:"beekeeperNotes,omitempty" json:"beekeeperNotes,omitempty"`
+	DisplayStatus          string    `firestore:"-" json:"displayStatus,omitempty"` // Transient, for frontend logic
+	NearestIntersection    string    `firestore:"nearestIntersection,omitempty" json:"nearestIntersection,omitempty"`
+	AssignedCollectorID    string    `firestore:"assignedCollectorID,omitempty" json:"assignedCollectorID,omitempty"`
 	AssignedCollectorEmail string    `firestore:"assignedCollectorEmail,omitempty" json:"assignedCollectorEmail,omitempty"`
 	// Contact information for public reporters
 	ReporterName      string `firestore:"reporterName,omitempty" json:"reporterName,omitempty"`

--- a/backend/templates/swarmlist.html
+++ b/backend/templates/swarmlist.html
@@ -14,6 +14,7 @@
 						<th>Reported</th>
 						<th>Last Updated</th>
 						<th>Reported Media</th>
+						<th>Action</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -21,7 +22,7 @@
 					<tr>
 						<td>{{.ID}}</td>
 						<td>{{.Description}}</td>
-						<td>{{.Status}}</td>
+						<td>{{.DisplayStatus}}</td>
 						<td class="location-info">
 							Lat: {{printf "%.6f" .Latitude}}<br>
 							Long: {{printf "%.6f" .Longitude}}
@@ -37,6 +38,16 @@
 								</button>
 							{{else}}
 								No media
+							{{end}}
+						</td>
+						<td>
+							{{if .AssignedCollectorEmail}}
+								<span class="badge badge-info">Claimed by {{.AssignedCollectorEmail}}</span>
+							{{else}}
+								<form action="/claim_swarm" method="POST" style="display:inline;">
+									<input type="hidden" name="swarmID" value="{{.ID}}">
+									<button type="submit" class="btn btn-sm btn-success">Offer to collect</button>
+								</form>
 							{{end}}
 						</td>
 					</tr>


### PR DESCRIPTION
### Description
This PR implements the 'Offer to collect' feature on the swarm list page. Swarm collectors can now officially claim a reported swarm for collection directly from the /swarmlist page.

### Changes
- **Model:** Added `AssignedCollectorEmail` to `SwarmReport` struct in `backend/models/models.go`.
- **Backend:**
    - Implemented `ClaimSwarmHandler` in `backend/handlers/swarm.go` to handle the collection offer.
    - Updated `AssignSwarmHandler` to also record the collector's email for consistency.
    - Registered the new `POST /claim_swarm` route in `backend/main.go`.
    - Updated `SwarmListHandler` in `backend/handlers/views.go` to include dynamic `DisplayStatus` logic.
- **Frontend:**
    - Updated `backend/templates/swarmlist.html` to add an 'Action' column with an 'Offer to collect' button for unassigned swarms.
    - Display a 'Claimed by [email]' badge for swarms that have already been claimed.
- **Tests:**
    - Added `TestClaimSwarmHandler` to `backend/handlers/handlers_test.go`.
    - Updated `TestAssignSwarmHandler` and `MockStore` to include collector email verification.

Fixes #31

Generated by **Overseer** (powered by the gemini-3-flash-preview model)