### PR TITLE
fix: Restore Workload Identity Federation for Deploy Pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: utba-swarmmap
   REGION: northamerica-northeast2
   SERVICE: utba-swarmmap-backend
   FRONTEND_SERVICE: utba-swarmmap-frontend
@@ -76,7 +76,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: 'projects/18499119240/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'github-actions-deployer@utba-swarmmap.iam.gserviceaccount.com'
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
The recent merge to `main` replaced the WIF deploy workflow with one expecting a legacy `GCP_SA_KEY` JSON secret. This caused the deployment pipeline to completely fail (Action Run 24165407944).

This PR surgically restores the secure Workload Identity Provider configuration into the new `.github/workflows/deploy.yml` so that automated deployment can resume safely using the `github-actions-deployer` service account.