### PR TITLE
Implement unclaim functionality in Register Swarms page

### DIFF
--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -1163,6 +1163,53 @@ func TestUsernameRegisterHandler(t *testing.T) {
 	}
 }
 
+func TestUnclaimSwarmHandler(t *testing.T) {
+	mockStore := &MockStore{
+		Swarms: []models.SwarmReport{
+			{
+				ID:                     "test-swarm-id",
+				Status:                 "Collection in Progress",
+				AssignedCollectorID:    "test-user",
+				AssignedCollectorEmail: "test@example.com",
+			},
+		},
+		Sessions: map[string]models.Session{
+			"test-session-id": {UserID: "test-user", Username: "test@example.com", Role: "collector", ExpiresAt: time.Now().Add(1 * time.Hour)},
+		},
+	}
+	h := &Handlers{
+		Store:        mockStore,
+		SwarmService: service.NewSwarmService(mockStore),
+	}
+
+	body := strings.NewReader("swarmID=test-swarm-id")
+	req, err := http.NewRequest("POST", "/unclaim_swarm", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "session", Value: "test-session-id"})
+
+	rr := httptest.NewRecorder()
+	handler := h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.UnclaimSwarmHandler)))
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusSeeOther {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusSeeOther)
+	}
+
+	if mockStore.Swarms[0].AssignedCollectorID != "" {
+		t.Errorf("expected AssignedCollectorID to be empty, got %v", mockStore.Swarms[0].AssignedCollectorID)
+	}
+	if mockStore.Swarms[0].AssignedCollectorEmail != "" {
+		t.Errorf("expected AssignedCollectorEmail to be empty, got %v", mockStore.Swarms[0].AssignedCollectorEmail)
+	}
+	if mockStore.Swarms[0].Status != "Reported" {
+		t.Errorf("expected swarm status to be 'Reported', got '%s'", mockStore.Swarms[0].Status)
+	}
+}
+
 func TestVerifyChecks(t *testing.T) {
 	if 1+1 != 2 {
 		t.Error("Math is broken")

--- a/backend/handlers/swarm.go
+++ b/backend/handlers/swarm.go
@@ -369,6 +369,43 @@ func (h *Handlers) ClaimSwarmHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/swarmlist", http.StatusSeeOther)
 }
 
+func (h *Handlers) UnclaimSwarmHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // Limit body to 1MB
+	session, ok := r.Context().Value(SessionContextKey).(*models.Session)
+	if !ok {
+		slog.Error("Could not retrieve session from context")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	swarmID := r.FormValue("swarmID")
+	if swarmID == "" {
+		http.Error(w, "Swarm ID required", http.StatusBadRequest)
+		return
+	}
+
+	var updates []firestore.Update
+	updates = append(updates, firestore.Update{Path: "assignedCollectorID", Value: ""})
+	updates = append(updates, firestore.Update{Path: "assignedCollectorEmail", Value: ""})
+	updates = append(updates, firestore.Update{Path: "status", Value: "Reported"})
+	updates = append(updates, firestore.Update{Path: "lastUpdatedTimestamp", Value: time.Now()})
+
+	if err := h.Store.UpdateSwarm(r.Context(), swarmID, updates); err != nil {
+		slog.Error("Failed to update swarm", "error", err, "id", h.sanitize(swarmID)) // #nosec G706
+		http.Error(w, "Failed to update swarm", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("Swarm unclaimed", "swarmID", h.sanitize(swarmID), "userID", h.sanitize(session.UserID)) // #nosec G706
+
+	http.Redirect(w, r, "/swarmlist", http.StatusSeeOther)
+}
+
 func (h *Handlers) validateFile(file *multipart.FileHeader) error {
 	if file.Size > maxFileSize {
 		return fmt.Errorf("file %s is too large (max size is 50MB)", file.Filename)

--- a/backend/main.go
+++ b/backend/main.go
@@ -149,6 +149,7 @@ func main() {
 	mux.Handle("POST /update_swarm_status", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.UpdateSwarmStatusHandler))))
 	mux.Handle("POST /assign_swarm", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.AssignSwarmHandler))))
 	mux.Handle("POST /claim_swarm", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.ClaimSwarmHandler))))
+	mux.Handle("POST /unclaim_swarm", h.RequireAuth(h.RequireRole("collector", http.HandlerFunc(h.UnclaimSwarmHandler))))
 	// Add other routes here as they are refactored
 
 	port := getEnv("PORT", "8080")

--- a/backend/templates/swarmlist.html
+++ b/backend/templates/swarmlist.html
@@ -43,7 +43,15 @@
 						</td>
 						<td>
 							{{if .AssignedCollectorEmail}}
-								<span class="badge bg-info">Claimed by {{.AssignedCollectorEmail}}</span>
+								<div class="d-flex flex-column gap-1">
+									<span class="badge bg-info">Claimed by {{.AssignedCollectorEmail}}</span>
+									{{if eq $.User.UserID .AssignedCollectorID}}
+									<form action="/unclaim_swarm" method="POST" style="display:inline;">
+										<input type="hidden" name="swarmID" value="{{.ID}}">
+										<button type="submit" class="btn btn-sm btn-outline-danger">Unclaim</button>
+									</form>
+									{{end}}
+								</div>
 							{{else}}
 								<form action="/claim_swarm" method="POST" style="display:inline;">
 									<input type="hidden" name="swarmID" value="{{.ID}}">


### PR DESCRIPTION
This PR implements the missing unclaim functionality in the Register Swarms page as described in issue #53.

Key changes:
- Added `UnclaimSwarmHandler` in `backend/handlers/swarm.go` to reset swarm assignment and status.
- Registered `POST /unclaim_swarm` route in `backend/main.go`.
- Updated `backend/templates/swarmlist.html` to display an 'Unclaim' button only for the collector who claimed the swarm.
- Added unit tests in `backend/handlers/handlers_test.go` to verify the unclaim logic.

Fixes #53

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).