### PR TITLE
fix: update CSP to allow Mapbox assets

### DIFF
--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -26,13 +26,13 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 
 		// Content Security Policy
-		// Allow self, Google Fonts, FontAwesome, OpenStreetMap tiles, and Nominatim
+		// Allow self, Google Fonts, FontAwesome, OpenStreetMap tiles, Mapbox, and Nominatim
 		csp := "default-src 'self'; " +
 			"script-src 'self' https://cdn.jsdelivr.net; " +
 			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com; " +
 			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; " +
-			"img-src 'self' data: https://*.tile.openstreetmap.org https://*.googleapis.com https://*.gstatic.com; " +
-			"connect-src 'self' https://nominatim.openstreetmap.org; " +
+			"img-src 'self' data: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.googleapis.com https://*.gstatic.com; " +
+			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com; " +
 			"frame-ancestors 'none';"
 
 		w.Header().Set("Content-Security-Policy", csp)

--- a/backend/handlers/middleware_test.go
+++ b/backend/handlers/middleware_test.go
@@ -49,6 +49,12 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "frame-ancestors 'none'") {
 		t.Errorf("expected CSP to contain frame-ancestors 'none', got %s", csp)
 	}
+	if !strings.Contains(csp, "https://api.mapbox.com") {
+		t.Errorf("expected CSP to contain https://api.mapbox.com, got %s", csp)
+	}
+	if !strings.Contains(csp, "https://*.mapbox.com") {
+		t.Errorf("expected CSP to contain https://*.mapbox.com, got %s", csp)
+	}
 }
 
 func TestVerifyCSRF(t *testing.T) {


### PR DESCRIPTION
This PR updates the Content Security Policy (CSP) to allow Mapbox tiles and geocoding requests.

The previous CSP was too restrictive and blocked Mapbox when it was enabled in production, leading to deployment validation failures in the newly added E2E tests.

### Changes:
- Added `https://api.mapbox.com` and `https://*.mapbox.com` to `img-src` in CSP.
- Added `https://api.mapbox.com` to `connect-src` in CSP.
- Updated unit tests to verify these domains are present in the CSP header.

Fixes #62

Generated by **Overseer** (powered by the gemini-3-flash-preview model).