### PR TITLE
fix: allow FrontendAssetsURL in CSP to fix deployment validation

### DIFF
--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -27,11 +27,16 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 
 		// Content Security Policy
 		// Allow self, Google Fonts, FontAwesome, OpenStreetMap tiles, Mapbox, and Nominatim
+		assetsURL := ""
+		if h.FrontendAssetsURL != "" {
+			assetsURL = " " + h.FrontendAssetsURL
+		}
+
 		csp := "default-src 'self'; " +
-			"script-src 'self' https://cdn.jsdelivr.net; " +
-			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com; " +
-			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; " +
-			"img-src 'self' data: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.googleapis.com https://*.gstatic.com; " +
+			"script-src 'self' https://cdn.jsdelivr.net" + assetsURL + "; " +
+			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
+			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
+			"img-src 'self' data: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.googleapis.com https://*.gstatic.com" + assetsURL + "; " +
 			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com; " +
 			"frame-ancestors 'none';"
 

--- a/backend/handlers/middleware_test.go
+++ b/backend/handlers/middleware_test.go
@@ -55,6 +55,24 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "https://*.mapbox.com") {
 		t.Errorf("expected CSP to contain https://*.mapbox.com, got %s", csp)
 	}
+
+	t.Run("CSP with FrontendAssetsURL", func(t *testing.T) {
+		h2 := &Handlers{FrontendAssetsURL: "https://assets.example.com"}
+		handler2 := h2.SecurityHeaders(nextHandler)
+		rr2 := httptest.NewRecorder()
+		handler2.ServeHTTP(rr2, req)
+		csp2 := rr2.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp2, "https://assets.example.com") {
+			t.Errorf("expected CSP to contain https://assets.example.com, got %s", csp2)
+		}
+		// Verify it's in multiple directives
+		directives := []string{"script-src", "style-src", "font-src", "img-src"}
+		for _, d := range directives {
+			if !strings.Contains(csp2, d) || !strings.Contains(strings.Split(csp2, d)[1], "https://assets.example.com") {
+				t.Errorf("expected %s to contain https://assets.example.com in %s", d, csp2)
+			}
+		}
+	})
 }
 
 func TestVerifyCSRF(t *testing.T) {


### PR DESCRIPTION
## Description
The deployment validation failed because the Content Security Policy (CSP) was blocking assets served from the separate frontend service in production. This PR updates the CSP to include the `FrontendAssetsURL` in the allowed origins for scripts, styles, fonts, and images.

## Changes
- Updated `SecurityHeaders` middleware in `backend/handlers/middleware.go` to include `h.FrontendAssetsURL` in CSP directives if it is set.
- Updated `backend/handlers/middleware_test.go` to verify the new CSP behavior.

Fixes #64

Generated by **Overseer** (powered by the gemini-3-flash-preview model).