### PR TITLE
fix: resolve deployment validation failure by updating CSP

### DIFF
--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -33,11 +33,11 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		}
 
 		csp := "default-src 'self'; " +
-			"script-src 'self' https://cdn.jsdelivr.net" + assetsURL + "; " +
+			"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net" + assetsURL + "; " +
 			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
 			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
-			"img-src 'self' data: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.googleapis.com https://*.gstatic.com" + assetsURL + "; " +
-			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com; " +
+			"img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.googleapis.com https://*.gstatic.com" + assetsURL + "; " +
+			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://events.mapbox.com; " +
 			"frame-ancestors 'none';"
 
 		w.Header().Set("Content-Security-Policy", csp)

--- a/backend/handlers/middleware_test.go
+++ b/backend/handlers/middleware_test.go
@@ -49,11 +49,20 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "frame-ancestors 'none'") {
 		t.Errorf("expected CSP to contain frame-ancestors 'none', got %s", csp)
 	}
+	if !strings.Contains(csp, "'unsafe-inline'") {
+		t.Errorf("expected CSP to contain 'unsafe-inline' in script-src, got %s", csp)
+	}
+	if !strings.Contains(csp, "blob:") {
+		t.Errorf("expected CSP to contain blob:, got %s", csp)
+	}
 	if !strings.Contains(csp, "https://api.mapbox.com") {
 		t.Errorf("expected CSP to contain https://api.mapbox.com, got %s", csp)
 	}
 	if !strings.Contains(csp, "https://*.mapbox.com") {
 		t.Errorf("expected CSP to contain https://*.mapbox.com, got %s", csp)
+	}
+	if !strings.Contains(csp, "https://events.mapbox.com") {
+		t.Errorf("expected CSP to contain https://events.mapbox.com, got %s", csp)
 	}
 
 	t.Run("CSP with FrontendAssetsURL", func(t *testing.T) {

--- a/e2e/validate-deployment.spec.js
+++ b/e2e/validate-deployment.spec.js
@@ -34,7 +34,7 @@ test('deployment validation - basic elements and assets', async ({ page }, testI
   await expect(map).toBeVisible();
   // Check if CSS is applied (map should have height set in style.css)
   const mapHeight = await map.evaluate(el => window.getComputedStyle(el).height);
-  expect(parseInt(mapHeight), 'Map height should be at least 400px').toBeGreaterThan(400);
+  expect(parseInt(mapHeight), 'Map height should be at least 400px').toBeGreaterThanOrEqual(400);
 
   const legend = page.locator('#legendTitle');
   await expect(legend).toBeVisible();


### PR DESCRIPTION
## Description
The post-deployment validation failed due to CSP violations and a slightly too-strict E2E test.

### Changes
1. **Updated CSP**:
    - Added `'unsafe-inline'` to `script-src` to allow inline scripts used for Mapbox token initialization and UI button handlers (e.g., `onclick`).
    - Added `blob:` to `img-src` to support map libraries that use Blob URLs for assets.
    - Expanded `connect-src` to include `https://*.mapbox.com` and `https://events.mapbox.com` to allow Mapbox telemetry and geocoding requests.
2. **Updated Middleware Tests**: Reflected the CSP changes in the backend tests to ensure future compliance.
3. **Robust E2E Tests**: Updated the map height check in `e2e/validate-deployment.spec.js` to use `toBeGreaterThanOrEqual(400)` instead of `toBeGreaterThan(400)` to prevent false positives when the height is exactly 400px.

Fixes #66

Generated by **Overseer** (powered by the gemini-3-flash-preview model).
