### PR TITLE
fix: expand CSP to resolve deployment validation failure

### DIFF
--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -33,11 +33,14 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		}
 
 		csp := "default-src 'self'; " +
-			"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net" + assetsURL + "; " +
-			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
-			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
-			"img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.googleapis.com https://*.gstatic.com" + assetsURL + "; " +
-			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://events.mapbox.com; " +
+			"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
+			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://fonts.googleapis.com https://cdnjs.cloudflare.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
+			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com" + assetsURL + "; " +
+			"img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://*.googleapis.com https://*.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com" + assetsURL + "; " +
+			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://events.mapbox.com" + assetsURL + "; " +
+			"worker-src 'self' blob:; " +
+			"child-src 'self' blob:; " +
+			"media-src 'self' https://*.googleapis.com; " +
 			"frame-ancestors 'none';"
 
 		w.Header().Set("Content-Security-Policy", csp)

--- a/backend/handlers/middleware_test.go
+++ b/backend/handlers/middleware_test.go
@@ -61,8 +61,17 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "https://*.mapbox.com") {
 		t.Errorf("expected CSP to contain https://*.mapbox.com, got %s", csp)
 	}
+	if !strings.Contains(csp, "https://unpkg.com") {
+		t.Errorf("expected CSP to contain https://unpkg.com, got %s", csp)
+	}
 	if !strings.Contains(csp, "https://events.mapbox.com") {
 		t.Errorf("expected CSP to contain https://events.mapbox.com, got %s", csp)
+	}
+	if !strings.Contains(csp, "worker-src 'self' blob:") {
+		t.Errorf("expected CSP to contain worker-src 'self' blob:, got %s", csp)
+	}
+	if !strings.Contains(csp, "media-src 'self' https://*.googleapis.com") {
+		t.Errorf("expected CSP to contain media-src 'self' https://*.googleapis.com, got %s", csp)
 	}
 
 	t.Run("CSP with FrontendAssetsURL", func(t *testing.T) {
@@ -75,7 +84,7 @@ func TestSecurityHeaders(t *testing.T) {
 			t.Errorf("expected CSP to contain https://assets.example.com, got %s", csp2)
 		}
 		// Verify it's in multiple directives
-		directives := []string{"script-src", "style-src", "font-src", "img-src"}
+		directives := []string{"script-src", "style-src", "font-src", "img-src", "connect-src"}
 		for _, d := range directives {
 			if !strings.Contains(csp2, d) || !strings.Contains(strings.Split(csp2, d)[1], "https://assets.example.com") {
 				t.Errorf("expected %s to contain https://assets.example.com in %s", d, csp2)


### PR DESCRIPTION
## Description
This PR expands the Content Security Policy (CSP) to resolve a deployment validation failure. The previous CSP was too restrictive, blocking essential assets and connections required by the mapping library (Leaflet/Mapbox), CDNs, and media storage.

### Key Changes
- **Directives Added**:
  - `worker-src` and `child-src`: Required for mapping libraries and plugins that utilize Web Workers.
  - `media-src`: Added to allow video content served from Google Cloud Storage (`*.googleapis.com`).
- **Domain Expansion**:
  - Added `unpkg.com` to `script-src`, `style-src`, `font-src`, and `img-src` to support various vendor assets.
  - Expanded `img-src` and `connect-src` to include `*.tiles.mapbox.com` and other Mapbox-related domains.
  - Added `cdn.jsdelivr.net` and `cdnjs.cloudflare.com` to `img-src` and `font-src` to ensure all library assets (like Leaflet markers or FontAwesome icons) can load.
  - Added `FrontendAssetsURL` to `connect-src` to allow potential API calls or asset fetching from the dedicated frontend service.

These changes make the application more robust across different environments and ensure that all interactive and media elements function correctly under strict security policies.

Fixes #68

Generated by **Overseer** (powered by the gemini-3-flash-preview model).