### PR TITLE
fix: expand CSP to resolve deployment validation failure

### DIFF
--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -33,14 +33,14 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		}
 
 		csp := "default-src 'self'; " +
-			"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
+			"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
 			"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://fonts.googleapis.com https://cdnjs.cloudflare.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
-			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com" + assetsURL + "; " +
-			"img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://*.googleapis.com https://*.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com" + assetsURL + "; " +
-			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://events.mapbox.com" + assetsURL + "; " +
-			"worker-src 'self' blob:; " +
-			"child-src 'self' blob:; " +
-			"media-src 'self' https://*.googleapis.com; " +
+			"font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com" + assetsURL + "; " +
+			"img-src 'self' data: blob: https://*.tile.openstreetmap.org https://tile.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://*.googleapis.com https://*.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com" + assetsURL + "; " +
+			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://events.mapbox.com https://*.tile.openstreetmap.org https://tile.openstreetmap.org" + assetsURL + "; " +
+			"worker-src 'self' blob:" + assetsURL + "; " +
+			"child-src 'self' blob:" + assetsURL + "; " +
+			"media-src 'self' https://*.googleapis.com" + assetsURL + "; " +
 			"frame-ancestors 'none';"
 
 		w.Header().Set("Content-Security-Policy", csp)

--- a/backend/handlers/middleware_test.go
+++ b/backend/handlers/middleware_test.go
@@ -55,6 +55,9 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "blob:") {
 		t.Errorf("expected CSP to contain blob:, got %s", csp)
 	}
+	if !strings.Contains(csp, "font-src 'self' data:") {
+		t.Errorf("expected CSP to contain font-src 'self' data:, got %s", csp)
+	}
 	if !strings.Contains(csp, "https://api.mapbox.com") {
 		t.Errorf("expected CSP to contain https://api.mapbox.com, got %s", csp)
 	}
@@ -66,6 +69,9 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 	if !strings.Contains(csp, "https://events.mapbox.com") {
 		t.Errorf("expected CSP to contain https://events.mapbox.com, got %s", csp)
+	}
+	if !strings.Contains(csp, "'unsafe-eval'") {
+		t.Errorf("expected CSP to contain 'unsafe-eval', got %s", csp)
 	}
 	if !strings.Contains(csp, "worker-src 'self' blob:") {
 		t.Errorf("expected CSP to contain worker-src 'self' blob:, got %s", csp)
@@ -84,7 +90,7 @@ func TestSecurityHeaders(t *testing.T) {
 			t.Errorf("expected CSP to contain https://assets.example.com, got %s", csp2)
 		}
 		// Verify it's in multiple directives
-		directives := []string{"script-src", "style-src", "font-src", "img-src", "connect-src"}
+		directives := []string{"script-src", "style-src", "font-src", "img-src", "connect-src", "worker-src", "child-src", "media-src"}
 		for _, d := range directives {
 			if !strings.Contains(csp2, d) || !strings.Contains(strings.Split(csp2, d)[1], "https://assets.example.com") {
 				t.Errorf("expected %s to contain https://assets.example.com in %s", d, csp2)


### PR DESCRIPTION
## Description
The post-deployment validation failed because the Content Security Policy (CSP) was too restrictive. This PR expands the CSP to include all necessary domains and directives required for the mapping services and frontend assets to load correctly.

### Key Changes
- Added `'unsafe-eval'` to `script-src` for library compatibility.
- Added `data:` to `font-src` to allow inline fonts.
- Included `https://tile.openstreetmap.org` in `img-src` and `connect-src`.
- Added `FrontendAssetsURL` to `worker-src`, `child-src`, and `media-src` directives.
- Expanded `connect-src` to include more OpenStreetMap and Mapbox domains.

Fixes #71

Generated by **Overseer** (powered by the gemini-3-flash-preview model).