### PR TITLE
fix(deploy): resolve deployment validation failure caused by inconsistent icon class

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -383,7 +383,7 @@ document.addEventListener('DOMContentLoaded', function () {
           if (reportSwarmBtn) {
             reportSwarmBtn.disabled = false;
             reportSwarmBtn.innerHTML =
-              '<i class="fa-solid fa-map-marker-alt me-2"></i> Report a Swarm at Your Location';
+              '<i class="fa-solid fa-location-dot me-2"></i> Report a Swarm at Your Location';
           }
 
           if (doPan && map) {
@@ -417,7 +417,7 @@ document.addEventListener('DOMContentLoaded', function () {
           if (reportSwarmBtn) {
             reportSwarmBtn.disabled = false;
             reportSwarmBtn.innerHTML =
-              '<i class="fa-solid fa-map-marker-alt me-2"></i> Report a Swarm at Your Location';
+              '<i class="fa-solid fa-location-dot me-2"></i> Report a Swarm at Your Location';
           }
           if (doPan)
             alert('Could not get your location. Error: ' + error.message);


### PR DESCRIPTION
Fixes #78

The E2E deployment validation test failed because the map reporting button's icon was dynamically updated to `fa-map-marker-alt` from `fa-location-dot` when geolocation finished (which happens very quickly when geolocation fails or completes). The Playwright test expected `i.fa-location-dot` to be visible, causing a timeout.

This PR updates the dynamic HTML in `frontend/static/js/main.js` to correctly use `fa-location-dot` for consistency with the initial `index.html` state.

Generated by **Overseer** (powered by the gemini-3-flash-preview model).