### PR TITLE
Fix: Restrict public map data to protect privacy

### DIFF
--- a/backend/handlers/contract_test.go
+++ b/backend/handlers/contract_test.go
@@ -29,6 +29,13 @@ func TestGetSwarms_Contract(t *testing.T) {
 				ReportedTimestamp:   time.Now(),
 			},
 		},
+		Sessions: map[string]models.Session{
+			"collector-session": {
+				UserID:    "collector-123",
+				Role:      "collector",
+				ExpiresAt: time.Now().Add(1 * time.Hour),
+			},
+		},
 	}
 	h := &Handlers{
 		Store:        mockStore,
@@ -36,6 +43,7 @@ func TestGetSwarms_Contract(t *testing.T) {
 	}
 
 	req, _ := http.NewRequest("GET", "/get_swarms", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "collector-session"})
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.GetSwarmsHandler)
 	handler.ServeHTTP(rr, req)

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -277,7 +277,16 @@ func TestGetSwarmsHandler_WithSwarms(t *testing.T) {
 		{ID: "2", Description: "Swarm 2", Status: "Captured", ReportedTimestamp: time.Now().Add(-25 * time.Hour)},
 		{ID: "3", Description: "Swarm 3", Status: "Reported", ReportedTimestamp: time.Now().Add(-25 * time.Hour)},
 	}
-	mockStore := &MockStore{Swarms: mockSwarms}
+	mockStore := &MockStore{
+		Swarms: mockSwarms,
+		Sessions: map[string]models.Session{
+			"collector-session": {
+				UserID:    "collector-123",
+				Role:      "collector",
+				ExpiresAt: time.Now().Add(1 * time.Hour),
+			},
+		},
+	}
 
 	// Initialize handlers with the mock store and swarm service
 	h := &Handlers{
@@ -289,6 +298,7 @@ func TestGetSwarmsHandler_WithSwarms(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.AddCookie(&http.Cookie{Name: "session", Value: "collector-session"})
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.GetSwarmsHandler)
@@ -321,6 +331,89 @@ func TestGetSwarmsHandler_WithSwarms(t *testing.T) {
 	}
 	if returnedSwarms[2].DisplayStatus != "Archived" {
 		t.Errorf("expected DisplayStatus to be 'Archived', got '%s'", returnedSwarms[2].DisplayStatus)
+	}
+}
+
+func TestGetSwarmsHandler_PublicRestriction(t *testing.T) {
+	// Prepare a mock store with some data
+	mockSwarms := []models.SwarmReport{
+		{ID: "1", Description: "Swarm 1", Status: "Reported", ReportedTimestamp: time.Now()},
+	}
+	mockStore := &MockStore{Swarms: mockSwarms}
+
+	// Initialize handlers with the mock store and swarm service
+	h := &Handlers{
+		Store:        mockStore,
+		SwarmService: service.NewSwarmService(mockStore),
+	}
+
+	// Request WITHOUT session or sessionId
+	req, err := http.NewRequest("GET", "/get_swarms", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(h.GetSwarmsHandler)
+	handler.ServeHTTP(rr, req)
+
+	// Check status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	var returnedSwarms []models.SwarmReport
+	if err := json.NewDecoder(rr.Body).Decode(&returnedSwarms); err != nil {
+		t.Fatalf("could not decode response body: %v", err)
+	}
+
+	if len(returnedSwarms) != 0 {
+		t.Errorf("public request should return 0 swarms, got %d", len(returnedSwarms))
+	}
+}
+
+func TestGetSwarmsHandler_ReporterSession(t *testing.T) {
+	// Prepare a mock store with some data
+	mockSwarms := []models.SwarmReport{
+		{ID: "1", Description: "Reporter Swarm", ReporterSessionID: "reporter-123", ReportedTimestamp: time.Now()},
+		{ID: "2", Description: "Other Swarm", ReporterSessionID: "other-456", ReportedTimestamp: time.Now()},
+	}
+	mockStore := &MockStore{Swarms: mockSwarms}
+
+	// Initialize handlers with the mock store and swarm service
+	h := &Handlers{
+		Store:        mockStore,
+		SwarmService: service.NewSwarmService(mockStore),
+	}
+
+	// Request WITH sessionId
+	req, err := http.NewRequest("GET", "/get_swarms?sessionId=reporter-123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(h.GetSwarmsHandler)
+	handler.ServeHTTP(rr, req)
+
+	// Check status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	var returnedSwarms []models.SwarmReport
+	if err := json.NewDecoder(rr.Body).Decode(&returnedSwarms); err != nil {
+		t.Fatalf("could not decode response body: %v", err)
+	}
+
+	if len(returnedSwarms) != 1 {
+		t.Errorf("reporter request should return 1 swarm, got %d", len(returnedSwarms))
+	}
+
+	if returnedSwarms[0].ID != "1" {
+		t.Errorf("reporter request returned wrong swarm: got %s want 1", returnedSwarms[0].ID)
 	}
 }
 

--- a/backend/handlers/views.go
+++ b/backend/handlers/views.go
@@ -5,7 +5,6 @@ package handlers
 import (
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/fkcurrie/utba-swarmmap/models"
 )
@@ -18,19 +17,11 @@ func (h *Handlers) SwarmListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	swarms, err := h.Store.GetAllSwarms(r.Context())
+	swarms, err := h.SwarmService.GetSwarms(r.Context(), "", session)
 	if err != nil {
 		slog.Error("Failed to retrieve swarms", "error", err)
 		http.Error(w, "Failed to retrieve swarms", http.StatusInternalServerError)
 		return
-	}
-
-	// Dynamic DisplayStatus logic
-	for i := range swarms {
-		swarms[i].DisplayStatus = swarms[i].Status
-		if swarms[i].Status != "Captured" && time.Since(swarms[i].ReportedTimestamp).Hours() > 24 {
-			swarms[i].DisplayStatus = "Archived"
-		}
 	}
 
 	err = h.Templates.ExecuteTemplate(w, "swarmlist.html", map[string]interface{}{

--- a/backend/handlers/views_test.go
+++ b/backend/handlers/views_test.go
@@ -11,12 +11,17 @@ import (
 	"time"
 
 	"github.com/fkcurrie/utba-swarmmap/models"
+	"github.com/fkcurrie/utba-swarmmap/service"
 )
 
 func TestSwarmListHandler(t *testing.T) {
 	mockStore := &MockStore{}
 	tmpl, _ := template.New("swarmlist.html").Parse("<html>Swarm List</html>")
-	h := &Handlers{Store: mockStore, Templates: tmpl}
+	h := &Handlers{
+		Store:        mockStore,
+		Templates:    tmpl,
+		SwarmService: service.NewSwarmService(mockStore),
+	}
 
 	req, _ := http.NewRequest("GET", "/swarmlist", nil)
 	session := &models.Session{Role: "collector", ExpiresAt: time.Now().Add(1 * time.Hour)}

--- a/backend/service/service.go
+++ b/backend/service/service.go
@@ -31,17 +31,21 @@ func (s *swarmService) GetSwarms(ctx context.Context, sessionID string, session 
 	var currentReports []models.SwarmReport
 	var err error
 
-	if sessionID != "" {
+	isCollector := session != nil && (session.Role == "collector" || session.Role == "collector_admin" || session.Role == "site_admin")
+
+	if isCollector {
+		currentReports, err = s.store.GetAllSwarms(ctx)
+	} else if sessionID != "" {
 		currentReports, err = s.store.GetSwarmsBySessionID(ctx, sessionID)
 	} else {
-		currentReports, err = s.store.GetAllSwarms(ctx)
+		// Public request: return nothing to protect privacy and prevent unauthorized interference.
+		// In the future, this could return a "general overview" (e.g. counts per region)
+		return []models.SwarmReport{}, nil
 	}
 
 	if err != nil {
 		return nil, err
 	}
-
-	isCollector := session != nil && (session.Role == "collector" || session.Role == "collector_admin" || session.Role == "site_admin")
 
 	for i := range currentReports {
 		currentReports[i].DisplayStatus = currentReports[i].Status

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -340,7 +340,9 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       const visitorId = localStorage.getItem('utba_visitor_id');
-      const url = visitorId ? `/get_swarms?sessionId=${visitorId}` : '/get_swarms';
+      const url = visitorId
+        ? `/get_swarms?sessionId=${visitorId}`
+        : '/get_swarms';
       const response = await fetch(url);
       if (!response.ok) throw new Error('Failed to fetch swarms');
       const swarms = await response.json();

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -339,7 +339,9 @@ document.addEventListener('DOMContentLoaded', function () {
           '<div class="text-center p-2"><div class="spinner-border spinner-border-sm text-primary" role="status"></div> Loading...</div>';
       }
 
-      const response = await fetch('/get_swarms');
+      const visitorId = localStorage.getItem('utba_visitor_id');
+      const url = visitorId ? `/get_swarms?sessionId=${visitorId}` : '/get_swarms';
+      const response = await fetch(url);
       if (!response.ok) throw new Error('Failed to fetch swarms');
       const swarms = await response.json();
 


### PR DESCRIPTION
This PR restricts the swarm data exposed on the public-facing map.

### Changes:
- Modified `backend/service/service.go` to restrict `GetSwarms` based on user role and session ID.
- Updated `frontend/static/js/main.js` to pass the visitor ID as `sessionId` when fetching swarms, allowing reporters to see their own reports.
- Refactored `SwarmListHandler` to use the service layer, ensuring consistent privacy filtering.
- Updated and added tests to verify the new access control logic.

### Rationale:
Exposing all active swarm locations to the general public could lead to unauthorized interference or privacy concerns for reporters. By restricting the view to only authorized collectors or the original reporter, we maintain the utility of the map for those who need it while protecting the data.

Fixes #79

Generated by **Overseer** (powered by the gemini-3-flash-preview model).