### PR TITLE
Fix deployment validation failure: CSP and Mapbox token

### DIFF
--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -56,6 +56,7 @@ steps:
         --set-env-vars=GOOGLE_REDIRECT_URL=${BACKEND_URL}/auth/google/callback
         --update-secrets=GOOGLE_CLIENT_ID=google-oauth-client-id:latest
         --update-secrets=GOOGLE_CLIENT_SECRET=google-oauth-client-secret:latest
+        --update-secrets=MAPBOX_ACCESS_TOKEN=mapbox-access-token:latest
         --quiet
   # Get the URL of the deployed service and write it to a file
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -33,7 +33,7 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		}
 
 		csp := "default-src 'self'; " +
-			"script-src 'self' 'unsafe-inline' https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
+			"script-src 'self' 'unsafe-inline' blob: https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
 			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
 			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
 			"img-src 'self' data: blob: https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://*.googleapis.com https://*.gstatic.com" + assetsURL + "; " +

--- a/backend/handlers/middleware_test.go
+++ b/backend/handlers/middleware_test.go
@@ -52,8 +52,8 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "'unsafe-inline'") {
 		t.Errorf("expected CSP to contain 'unsafe-inline' in script-src, got %s", csp)
 	}
-	if !strings.Contains(csp, "blob:") {
-		t.Errorf("expected CSP to contain blob:, got %s", csp)
+	if !strings.Contains(csp, "script-src 'self' 'unsafe-inline' blob:") {
+		t.Errorf("expected CSP to contain blob: in script-src, got %s", csp)
 	}
 	if !strings.Contains(csp, "https://api.mapbox.com") {
 		t.Errorf("expected CSP to contain https://api.mapbox.com, got %s", csp)


### PR DESCRIPTION
Fixes #76.

This PR addresses the deployment validation failure for the Mapbox migration. 

Changes:
- Added `blob:` to `script-src` in CSP to support Mapbox GL JS workers.
- Added `MAPBOX_ACCESS_TOKEN` to `backend/cloudbuild.yaml` for proper deployment.
- Updated unit tests to verify CSP changes.

Generated by **Overseer** (powered by the gemini-3-flash-preview model).