### PR TITLE
Fix deployment validation: Improve Mapbox initialization and CSP

### DIFF
--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -35,11 +35,11 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		csp := "default-src 'self'; " +
 			"script-src 'self' 'unsafe-inline' blob: https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
 			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
-			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com" + assetsURL + "; " +
+			"font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
 			"img-src 'self' data: blob: https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://*.googleapis.com https://*.gstatic.com" + assetsURL + "; " +
 			"connect-src 'self' https://nominatim.openstreetmap.org https://api.mapbox.com https://*.mapbox.com https://*.tiles.mapbox.com https://events.mapbox.com" + assetsURL + "; " +
-			"worker-src 'self' blob:" + assetsURL + "; " +
-			"child-src 'self' blob:" + assetsURL + "; " +
+			"worker-src 'self' blob: https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
+			"child-src 'self' blob: https://api.mapbox.com https://*.mapbox.com" + assetsURL + "; " +
 			"media-src 'self' https://*.googleapis.com" + assetsURL + "; " +
 			"frame-ancestors 'none';"
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	// Initialize LocationService
 	var locationService handlers.LocationService
-	mapboxToken := os.Getenv("MAPBOX_ACCESS_TOKEN")
+	mapboxToken := strings.TrimSpace(os.Getenv("MAPBOX_ACCESS_TOKEN"))
 	if mapboxToken != "" {
 		locationService = &handlers.MapboxLocationService{
 			Client:      &http.Client{Timeout: 10 * time.Second},
@@ -121,7 +121,7 @@ func main() {
 		GoogleOAuthConfig: googleOAuthConfig,
 		Version:           version,
 		Templates:         templates,
-		FrontendAssetsURL: getEnv("FRONTEND_ASSETS_URL", ""), // Default to empty string for local dev
+		FrontendAssetsURL: strings.TrimSpace(getEnv("FRONTEND_ASSETS_URL", "")), // Default to empty string for local dev
 		MapboxToken:       mapboxToken,
 	}
 

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -21,14 +21,26 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (mapElement) {
     if (window.MAPBOX_TOKEN && window.MAPBOX_TOKEN !== '') {
+      if (typeof mapboxgl === 'undefined') {
+        console.error('Mapbox GL JS is not loaded. Check script include in footer.html.');
+        mapElement.innerHTML = '<div class="alert alert-danger m-3">Mapbox library failed to load.</div>';
+        return;
+      }
+      
       mapboxgl.accessToken = window.MAPBOX_TOKEN;
 
-      map = new mapboxgl.Map({
-        container: 'map',
-        style: 'mapbox://styles/mapbox/streets-v12',
-        center: [-79.3832, 43.6532],
-        zoom: 11,
-      });
+      try {
+        map = new mapboxgl.Map({
+          container: 'map',
+          style: 'mapbox://styles/mapbox/streets-v12',
+          center: [-79.3832, 43.6532],
+          zoom: 11,
+        });
+      } catch (e) {
+        console.error('Failed to initialize Mapbox map:', e);
+        mapElement.innerHTML = `<div class="alert alert-danger m-3">Map initialization error: ${e.message}</div>`;
+        return;
+      }
 
       map.addControl(new mapboxgl.NavigationControl());
 
@@ -239,6 +251,7 @@ document.addEventListener('DOMContentLoaded', function () {
         reportModal.show();
       });
     } else {
+      console.error('Mapbox token is missing. Map will not be initialized.');
       mapElement.innerHTML =
         '<div class="alert alert-warning m-3">Mapbox token is missing. Please configure MAPBOX_ACCESS_TOKEN.</div>';
     }

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -22,11 +22,14 @@ document.addEventListener('DOMContentLoaded', function () {
   if (mapElement) {
     if (window.MAPBOX_TOKEN && window.MAPBOX_TOKEN !== '') {
       if (typeof mapboxgl === 'undefined') {
-        console.error('Mapbox GL JS is not loaded. Check script include in footer.html.');
-        mapElement.innerHTML = '<div class="alert alert-danger m-3">Mapbox library failed to load.</div>';
+        console.error(
+          'Mapbox GL JS is not loaded. Check script include in footer.html.',
+        );
+        mapElement.innerHTML =
+          '<div class="alert alert-danger m-3">Mapbox library failed to load.</div>';
         return;
       }
-      
+
       mapboxgl.accessToken = window.MAPBOX_TOKEN;
 
       try {


### PR DESCRIPTION
## Description
This PR addresses the deployment validation failure (Issue #98) where the Mapbox map failed to render on the main page.

### Key Changes:
- **Environment Variable Sanitization:** Trims whitespace and newlines from `MAPBOX_ACCESS_TOKEN` and `FRONTEND_ASSETS_URL` in the backend to prevent configuration issues from Secret Manager.
- **CSP Improvements:** Updates the Content Security Policy to explicitly allow Mapbox domains in `worker-src`, `child-src`, and `font-src`, which is required for Mapbox GL JS v3 to function correctly in strict environments.
- **Enhanced Diagnostics:** Adds explicit checks and console logging in the frontend (`main.js`) to help identify map initialization failures, script loading issues, or missing tokens.

Fixes #98

Generated by **Overseer** (powered by the gemini-3-flash-preview model).