### PR TITLE
fix(e2e): restore legend ID and align colors for deployment validation

### DIFF
--- a/backend/templates/collectors_map.html
+++ b/backend/templates/collectors_map.html
@@ -33,19 +33,19 @@
                         <h2 class="h6 fw-bold mb-4 tracking-wider text-uppercase text-muted"><i class="fa-solid fa-circle-info me-2 text-warning"></i>Status Legend</h2>
                         <div class="d-flex flex-column gap-3" role="list">
                             <div class="legend-item d-flex align-items-center" role="listitem">
-                                <span class="legend-color" style="background-color: #e84118;" aria-hidden="true"></span>
+                                <span class="legend-color" style="background-color: rgb(255, 0, 0);" aria-hidden="true"></span>
                                 <span class="small fw-bold text-uppercase tracking-wider">Reported (New)</span>
                             </div>
                             <div class="legend-item d-flex align-items-center" role="listitem">
-                                <span class="legend-color" style="background-color: #fbc531;" aria-hidden="true"></span>
+                                <span class="legend-color" style="background-color: rgb(255, 105, 180);" aria-hidden="true"></span>
                                 <span class="small fw-bold text-uppercase tracking-wider">Verified</span>
                             </div>
                             <div class="legend-item d-flex align-items-center" role="listitem">
-                                <span class="legend-color" style="background-color: #4cd137;" aria-hidden="true"></span>
+                                <span class="legend-color" style="background-color: rgb(0, 255, 0);" aria-hidden="true"></span>
                                 <span class="small fw-bold text-uppercase tracking-wider">Captured</span>
                             </div>
                             <div class="legend-item d-flex align-items-center" role="listitem">
-                                <span class="legend-color" style="background-color: #487eb0;" aria-hidden="true"></span>
+                                <span class="legend-color" style="background-color: rgb(0, 0, 255);" aria-hidden="true"></span>
                                 <span class="small fw-bold text-uppercase tracking-wider">Archived (24h+)</span>
                             </div>
                         </div>

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -32,24 +32,27 @@
             </div>
         </div>
 
-        <!-- Pin Color Legend -->
+        <!-- Map Legend -->
         <aside class="row mt-5 mb-5" aria-labelledby="legendTitle">
             <div class="col-md-12">
+                <div class="text-center mb-4">
+                    <h2 id="legendTitle" class="h5 fw-bold"><i class="fa-solid fa-circle-info me-2 text-primary"></i>Map Legend</h2>
+                </div>
                 <div class="d-flex flex-wrap justify-content-center gap-3" role="list">
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: #e84118;" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(255, 0, 0);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Reported</span>
                     </div>
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: #fbc531;" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(255, 105, 180);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Verified</span>
                     </div>
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: #4cd137;" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(0, 255, 0);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Captured</span>
                     </div>
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: #487eb0;" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(0, 0, 255);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Archived</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Description
The post-deployment validation failed because the legend title ID was missing from the home page, and the legend colors were out of sync with the E2E test expectations and the actual Mapbox marker colors.

This PR:
- Restores `id='legendTitle'` to the legend heading in `index.html`.
- Updates legend colors to match the Mapbox implementation (Red, Pink, Green, Blue) and E2E test assertions.
- Ensures consistency across `index.html` and `collectors_map.html`.

Fixes #108

Generated by **Overseer** (powered by the gemini-3-flash-preview model).