### PR TITLE
Fix: Improve backend robustness and asset serving

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: Build and Push Backend
         run: |
+          cp -r frontend/static backend/static
           IMAGE_NAME="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/backend"
           docker build -t "$IMAGE_NAME:${{ github.sha }}" ./backend
           docker tag "$IMAGE_NAME:${{ github.sha }}" "$IMAGE_NAME:latest"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,9 @@ RUN apk add --no-cache tzdata
 WORKDIR /app
 COPY --from=builder /app/server /app/server
 COPY --from=builder /src/templates /app/templates/
+# Copy static assets if they were provided in the build context
+# We use a wildcard to avoid failure if the directory is missing
+COPY static* /app/static/
 
 ENV PORT=8080
 EXPOSE 8080

--- a/backend/main.go
+++ b/backend/main.go
@@ -113,6 +113,9 @@ func main() {
 		slog.Info("Using Nominatim Location Service")
 	}
 
+	frontendAssetsURL := strings.TrimSpace(getEnv("FRONTEND_ASSETS_URL", ""))
+	frontendAssetsURL = strings.TrimSuffix(frontendAssetsURL, "/")
+
 	// Initialize handlers with dependencies
 	h := &handlers.Handlers{
 		Store:             dataStore,
@@ -121,11 +124,18 @@ func main() {
 		GoogleOAuthConfig: googleOAuthConfig,
 		Version:           version,
 		Templates:         templates,
-		FrontendAssetsURL: strings.TrimSpace(getEnv("FRONTEND_ASSETS_URL", "")), // Default to empty string for local dev
+		FrontendAssetsURL: frontendAssetsURL,
 		MapboxToken:       mapboxToken,
 	}
 
 	mux := http.NewServeMux()
+
+	// Serve static files if they exist locally (fallback for when FRONTEND_ASSETS_URL is empty)
+	if _, err := os.Stat("static"); err == nil {
+		slog.Info("Serving static files from local directory")
+		fs := http.FileServer(http.Dir("static"))
+		mux.Handle("GET /static/", http.StripPrefix("/static/", fs))
+	}
 
 	// Public routes
 	mux.HandleFunc("GET /{$}", h.IndexHandler)

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -34,11 +34,6 @@
 
         <!-- Map Legend -->
         <aside class="row mt-5 mb-5" aria-labelledby="legendTitle">
-            <div class="col-md-12 text-center mb-3">
-                <h2 id="legendTitle" class="h6 fw-bold text-uppercase tracking-wider text-muted">
-                    <i class="fa-solid fa-circle-info me-2 text-warning"></i>Map Legend
-                </h2>
-            </div>
             <div class="col-md-12">
                 <div class="text-center mb-4">
                     <h2 id="legendTitle" class="h5 fw-bold"><i class="fa-solid fa-circle-info me-2 text-primary"></i>Map Legend</h2>

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -715,6 +715,11 @@ async function getNearestIntersection(lat, lng) {
   try {
     const response = await fetch(
       `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`,
+      {
+        headers: {
+          'User-Agent': 'utba-swarmmap (fkcurrie/utba-swarmmap)',
+        },
+      },
     );
     if (!response.ok) throw new Error('Nominatim error');
     const data = await response.json();


### PR DESCRIPTION
## Description
This PR addresses the deployment validation failure reported in Issue #110. The failure was likely caused by the backend service being unable to serve static assets when tested directly, especially if the `FRONTEND_ASSETS_URL` environment variable was empty or misconfigured.

### Key Changes:
- **Local Asset Serving:** The backend now includes a static file handler that serves assets from a local `static` directory if present. This provides a robust fallback.
- **Image Bundling:** Updated the backend `Dockerfile` and the GitHub deployment workflow to bundle the `static` directory into the backend image.
- **URL Sanitization:** Added logic to trim trailing slashes from `FRONTEND_ASSETS_URL` to prevent broken asset URLs.
- **API Compliance:** Added the required `User-Agent` header to Nominatim fetch calls in the frontend JavaScript to comply with their usage policy.

Fixes #110

Generated by **Overseer** (powered by the gemini-3-flash-preview model).