### PR TITLE
Fix deployment validation: duplicate ID and color mismatch

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -34,30 +34,27 @@
 
         <!-- Map Legend -->
         <aside class="row mt-5 mb-5" aria-labelledby="legendTitle">
-            <div class="col-md-12 text-center mb-3">
-                <h2 id="legendTitle" class="h6 fw-bold text-uppercase tracking-wider text-muted">
+            <div class="col-md-12 text-center mb-4">
+                <h2 id="legendTitle" class="h5 fw-bold">
                     <i class="fa-solid fa-circle-info me-2 text-warning"></i>Map Legend
                 </h2>
             </div>
             <div class="col-md-12">
-                <div class="text-center mb-4">
-                    <h2 id="legendTitle" class="h5 fw-bold"><i class="fa-solid fa-circle-info me-2 text-primary"></i>Map Legend</h2>
-                </div>
                 <div class="d-flex flex-wrap justify-content-center gap-3" role="list">
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(255, 0, 0);" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(232, 65, 24);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Reported</span>
                     </div>
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(255, 105, 180);" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(251, 197, 49);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Verified</span>
                     </div>
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(0, 255, 0);" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(76, 209, 55);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Captured</span>
                     </div>
                     <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(0, 0, 255);" aria-hidden="true"></span>
+                        <span class="legend-color" style="background-color: rgb(72, 126, 176);" aria-hidden="true"></span>
                         <span class="small fw-bold text-uppercase tracking-wider">Archived</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Description

This PR fixes two issues in the  template that were likely causing the deployment validation failure:

1. **Duplicate ID:** Removed a duplicate  ID which likely triggered a strict mode violation in Playwright tests.
2. **Color Mismatch:** Updated hardcoded legend colors to match the modern palette expected by the E2E tests and used in the Mapbox map layers.

Fixes #115

Generated by **Overseer** (powered by gemini-3-flash-preview model).