### PR TITLE
Fix: Resolve Deployment Validation Failure by Improving Backend Robustness

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -130,33 +130,22 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	// Serve static files if they exist locally (fallback for when FRONTEND_ASSETS_URL is empty)
-	if _, err := os.Stat("static"); err == nil {
-		slog.Info("Serving static files from local directory")
-		fs := http.FileServer(http.Dir("static"))
+	// Static file handler
+	// This consolidated handler serves static assets from ./static (for production/Docker)
+	// or ../frontend/static (for local development), ensuring backend self-sufficiency.
+	staticDir := "./static"
+	if _, err := os.Stat(staticDir); os.IsNotExist(err) {
+		staticDir = "../frontend/static"
+	}
+
+	if _, err := os.Stat(staticDir); err == nil {
+		slog.Info("Serving static files", "dir", staticDir)
+		fs := http.FileServer(http.Dir(staticDir))
 		mux.Handle("GET /static/", http.StripPrefix("/static/", fs))
 	}
 
 	// Public routes
 	mux.HandleFunc("GET /{$}", h.IndexHandler)
-
-	// Static file handler (fallback for local development)
-	// We check if ./static exists and serve from there if FRONTEND_ASSETS_URL is empty
-	if h.FrontendAssetsURL == "" {
-		// In production, assets are served by the frontend service or a CDN.
-		// For local dev, we might have a symbolic link or the static dir copied here.
-		// We try to serve from ../frontend/static if it exists, or ./static
-		staticDir := "./static"
-		if _, err := os.Stat(staticDir); os.IsNotExist(err) {
-			staticDir = "../frontend/static"
-		}
-		if _, err := os.Stat(staticDir); err == nil {
-			slog.Info("Serving static files from", "dir", staticDir)
-			fs := http.FileServer(http.Dir(staticDir))
-			mux.Handle("GET /static/", http.StripPrefix("/static/", fs))
-		}
-	}
-
 	mux.HandleFunc("GET /get_swarms", h.GetSwarmsHandler)
 	mux.HandleFunc("GET /login", h.LoginPageHandler)
 	mux.HandleFunc("GET /register", h.RegisterPageHandler)

--- a/backend/templates/admin.html
+++ b/backend/templates/admin.html
@@ -272,7 +272,7 @@
         </section>
     </div>
 
-    <script src="{{if .FrontendAssetsURL}}{{.FrontendAssetsURL}}{{end}}/static/vendor/chart.js/chart.umd.js"></script>
+    <script src="/static/vendor/chart.js/chart.umd.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const ctx = document.getElementById('trafficChart').getContext('2d');

--- a/backend/templates/footer.html
+++ b/backend/templates/footer.html
@@ -43,8 +43,8 @@
         </div>
     </div>
 
-    <script src="{{if .FrontendAssetsURL}}{{.FrontendAssetsURL}}{{end}}/static/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.2.0/mapbox-gl.js"></script>
-    <script src="{{if .FrontendAssetsURL}}{{.FrontendAssetsURL}}{{end}}/static/js/main.js"></script>
+    <script src="/static/js/main.js"></script>
 </body>
 </html>

--- a/backend/templates/header.html
+++ b/backend/templates/header.html
@@ -9,10 +9,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{if .FrontendAssetsURL}}{{.FrontendAssetsURL}}{{end}}/static/vendor/bootstrap/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{if .FrontendAssetsURL}}{{.FrontendAssetsURL}}{{end}}/static/vendor/fontawesome/css/all.min.css">
+    <link rel="stylesheet" href="/static/vendor/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/vendor/fontawesome/css/all.min.css">
     <link href="https://api.mapbox.com/mapbox-gl-js/v3.2.0/mapbox-gl.css" rel="stylesheet" />
-    <link rel="stylesheet" href="{{if .FrontendAssetsURL}}{{.FrontendAssetsURL}}{{end}}/static/css/style.css">
+    <link rel="stylesheet" href="/static/css/style.css">
     <script>
         window.MAPBOX_TOKEN = "{{.MapboxToken}}";
     </script>


### PR DESCRIPTION
## Description
This PR addresses the deployment validation failure reported in Issue #122.

### Changes:
- **Consolidated Static Asset Handling:** Cleaned up duplicate static file handler registrations in `backend/main.go` that could lead to panics if `FRONTEND_ASSETS_URL` was unset.
- **Improved Asset Reliability:** Updated `header.html`, `footer.html`, and `admin.html` templates to use relative paths (`/static/...`) for internal assets. This removes the dependency on the separate frontend service for serving basic UI resources, ensuring the backend is self-sufficient during validation.
- **Robust Local Fallback:** Refined the logic to detect and serve static assets from either the local `./static` directory (standard in Docker) or the `../frontend/static` directory (facilitating local development).

These changes ensure that the backend service can reliably serve its own UI and assets, which is critical for the success of post-deployment validation tests.

Fixes #122

Generated by **Overseer** (powered by the gemini-3-flash-preview model).