### PR TITLE
Fix: Improve deployment validation robustness and URL handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,7 +153,17 @@ jobs:
         id: validation
         env:
           DEPLOYED_URL: ${{ steps.deploy-backend.outputs.url }}
+          FALLBACK_URL: ${{ steps.backend-url.outputs.url }}
         run: |
+          # Ensure DEPLOYED_URL is set, fallback to backend-url output if necessary
+          FINAL_URL="${DEPLOYED_URL:-$FALLBACK_URL}"
+          echo "Validating deployment at URL: $FINAL_URL"
+          if [ -z "$FINAL_URL" ] || [ "$FINAL_URL" == "http://localhost:8085" ]; then
+            echo "Error: Could not determine deployment URL. DEPLOYED_URL='$DEPLOYED_URL', FALLBACK_URL='$FALLBACK_URL'"
+            exit 1
+          fi
+          # Export for Playwright to pick up
+          export DEPLOYED_URL="$FINAL_URL"
           npx playwright install --with-deps chromium
           npx playwright test e2e/validate-deployment.spec.js --config e2e/playwright.config.js
 

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.DEPLOYED_URL || 'http://localhost:8085',
+    baseURL: process.env.DEPLOYED_URL || process.env.BASE_URL || 'http://localhost:8085',
 
     /* Collect trace when retrying a failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/e2e/validate-deployment.spec.js
+++ b/e2e/validate-deployment.spec.js
@@ -36,6 +36,7 @@ test('deployment validation - basic elements and assets', async ({ page }, testI
     }
   });
 
+  console.log(`Validating deployment at: ${testInfo.project.use.baseURL || 'default'}`);
   await page.goto('/');
 
   // 1. Verify basic page title/content


### PR DESCRIPTION
## Description
This PR improves the robustness of the post-deployment validation process by ensuring the deployment URL is correctly passed to and handled by Playwright. 

Key changes:
- **GitHub Actions Workflow**: Updated the `Post-Deployment Validation` step to explicitly handle the `DEPLOYED_URL` from the backend deployment output, with a fallback to the predicted URL. Added validation and debugging output for the URL.
- **Playwright Configuration**: Updated `baseURL` to handle multiple environment variable names (`DEPLOYED_URL` or `BASE_URL`) and provided a more descriptive fallback for local development.
- **E2E Tests**: Added logging of the URL being tested in Playwright to improve observability in CI.

These changes address the issue where the validation was falling back to `localhost:8085` in the CI environment, leading to connection refusal errors.

Fixes #141

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).