### PR TITLE
fix: Feedback submission fails due to missing GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,7 @@ jobs:
             GOOGLE_CLIENT_ID=google-oauth-client-id:latest
             GOOGLE_CLIENT_SECRET=google-oauth-client-secret:latest
             MAPBOX_ACCESS_TOKEN=mapbox-access-token:latest
+            GITHUB_TOKEN=github-pat:latest
       - name: Health Check
         id: health-check
         run: |

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ The application can be configured using the following environment variables:
 
 - `MAPBOX_ACCESS_TOKEN`: (Optional) If provided, the application will use Mapbox for map tiles and reverse geocoding.
 - `FRONTEND_ASSETS_URL`: The URL of the frontend service serving static assets.
-- `GOOGLE_OAUTH_CLIENT_ID`: Required for Google OAuth.
-- `GOOGLE_OAUTH_CLIENT_SECRET`: Required for Google OAuth.
+- `GOOGLE_CLIENT_ID`: Required for Google OAuth.
+- `GOOGLE_CLIENT_SECRET`: Required for Google OAuth.
+- `GITHUB_TOKEN`: Required for feedback submission. A Personal Access Token with repo scope.
+- `GITHUB_REPO`: (Optional) The GitHub repository where feedback issues will be created (default: `fkcurrie/utba-swarmmap`).
 
 ## Local Development & Deployment
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -122,6 +122,12 @@ func main() {
 		githubRepo = "fkcurrie/utba-swarmmap"
 	}
 
+	if githubToken == "" {
+		slog.Warn("GITHUB_TOKEN is not set; feedback submission will be disabled")
+	} else {
+		slog.Info("GitHub integration configured", "repo", githubRepo)
+	}
+
 	// Initialize handlers with dependencies
 	h := &handlers.Handlers{
 		Store:             dataStore,


### PR DESCRIPTION
Fixes #149

This PR addresses the issue where feedback submission fails because the `GITHUB_TOKEN` environment variable is not injected into the Cloud Run backend container.

### Changes:
- Updated `.github/workflows/deploy.yml` to inject the `GITHUB_TOKEN` secret into the Cloud Run backend service.
- Modified `backend/main.go` to log a warning if `GITHUB_TOKEN` is missing during startup, or an info message if it is configured.
- Updated `README.md` to document `GITHUB_TOKEN` and `GITHUB_REPO` environment variables.
- Corrected inconsistent Google OAuth environment variable names in `README.md`.

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).