### PR TITLE
fix(ci): restore deployment pipeline and improve validation robustness

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,12 +108,12 @@ jobs:
       - name: Get Backend URL
         id: backend-url
         run: |
-          URL=$(gcloud run services describe ${{ env.SERVICE }} \
+          URL=$(gcloud run services describe "${{ env.SERVICE }}" \
             --platform=managed \
-            --region=${{ env.REGION }} \
+            --region="${{ env.REGION }}" \
             --format='value(status.url)' 2>/dev/null || echo "")
           if [ -z "$URL" ]; then
-            PROJECT_NUMBER=$(gcloud projects describe ${{ env.PROJECT_ID }} --format='value(projectNumber)')
+            PROJECT_NUMBER=$(gcloud projects describe "${{ env.PROJECT_ID }}" --format='value(projectNumber)')
             URL="https://${{ env.SERVICE }}-${PROJECT_NUMBER}.${{ env.REGION }}.run.app"
           fi
           echo "url=$URL" >> $GITHUB_OUTPUT
@@ -155,13 +155,13 @@ jobs:
           DEPLOYED_URL="${{ steps.deploy-backend.outputs.url }}"
           BACKEND_URL="${{ steps.backend-url.outputs.url }}"
           FINAL_URL="${DEPLOYED_URL:-$BACKEND_URL}"
-          
+
           echo "Validating deployment at URL: $FINAL_URL"
           if [ -z "$FINAL_URL" ] || [ "$FINAL_URL" == "http://localhost:8085" ]; then
             echo "Error: Could not determine deployment URL. DEPLOYED_URL='$DEPLOYED_URL', BACKEND_URL='$BACKEND_URL'"
             exit 1
           fi
-          
+
           npx playwright install --with-deps chromium
           # Pass DEPLOYED_URL explicitly to the test command
           DEPLOYED_URL="$FINAL_URL" npx playwright test e2e/validate-deployment.spec.js --config e2e/playwright.config.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@
 name: Deploy to Cloud Run
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 env:
@@ -16,3 +21,168 @@ env:
 jobs:
   deploy:
     name: Validate, Build, and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Linting
+        run: |
+          npx eslint "frontend/static/js/**/*.js"
+          npx markdownlint "**/*.md" --ignore node_modules
+
+      - name: YAML Lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: .
+          config_file: .yamllint.yaml
+
+      - name: Commitlint
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Backend Testing
+        run: |
+          cd backend
+          go test -v ./...
+
+      - name: Docker Build Test
+        run: |
+          docker build -t test-backend ./backend
+          docker build -t test-frontend ./frontend
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/18499119240/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'github-actions-deployer@utba-swarmmap.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and Push Frontend
+        run: |
+          IMAGE_NAME="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/frontend"
+          docker build -t "$IMAGE_NAME:${{ github.sha }}" ./frontend
+          docker tag "$IMAGE_NAME:${{ github.sha }}" "$IMAGE_NAME:latest"
+          docker push "$IMAGE_NAME:${{ github.sha }}"
+          docker push "$IMAGE_NAME:latest"
+
+      - name: Deploy Frontend to Cloud Run
+        id: deploy-frontend
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.FRONTEND_SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/frontend:${{ github.sha }}
+          flags: --allow-unauthenticated
+
+      - name: Get Backend URL
+        id: backend-url
+        run: |
+          URL=$(gcloud run services describe ${{ env.SERVICE }} \
+            --platform=managed \
+            --region=${{ env.REGION }} \
+            --format='value(status.url)' 2>/dev/null || echo "")
+          if [ -z "$URL" ]; then
+            PROJECT_NUMBER=$(gcloud projects describe ${{ env.PROJECT_ID }} --format='value(projectNumber)')
+            URL="https://${{ env.SERVICE }}-${PROJECT_NUMBER}.${{ env.REGION }}.run.app"
+          fi
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Build and Push Backend
+        run: |
+          cp -r frontend/static backend/static
+          IMAGE_NAME="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/backend"
+          docker build -t "$IMAGE_NAME:${{ github.sha }}" ./backend
+          docker tag "$IMAGE_NAME:${{ github.sha }}" "$IMAGE_NAME:latest"
+          docker push "$IMAGE_NAME:${{ github.sha }}"
+          docker push "$IMAGE_NAME:latest"
+
+      - name: Deploy Backend to Cloud Run
+        id: deploy-backend
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/backend:${{ github.sha }}
+          flags: --allow-unauthenticated
+          env_vars: |
+            GOOGLE_REDIRECT_URL=${{ steps.backend-url.outputs.url }}/auth/google/callback
+            GCP_PROJECT_ID=${{ env.PROJECT_ID }}
+            GCS_BUCKET_NAME=${{ env.GCS_BUCKET_NAME }}
+          secrets: |
+            GOOGLE_CLIENT_ID=google-oauth-client-id:latest
+            GOOGLE_CLIENT_SECRET=google-oauth-client-secret:latest
+            MAPBOX_ACCESS_TOKEN=mapbox-access-token:latest
+      - name: Health Check
+        id: health-check
+        run: |
+          curl --retry 5 --retry-all-errors --retry-delay 5 -I --fail --silent --show-error "${{ steps.deploy-backend.outputs.url }}"
+
+      - name: Post-Deployment Validation
+        id: validation
+        run: |
+          # Use outputs directly to ensure we have the latest values
+          DEPLOYED_URL="${{ steps.deploy-backend.outputs.url }}"
+          BACKEND_URL="${{ steps.backend-url.outputs.url }}"
+          FINAL_URL="${DEPLOYED_URL:-$BACKEND_URL}"
+          
+          echo "Validating deployment at URL: $FINAL_URL"
+          if [ -z "$FINAL_URL" ] || [ "$FINAL_URL" == "http://localhost:8085" ]; then
+            echo "Error: Could not determine deployment URL. DEPLOYED_URL='$DEPLOYED_URL', BACKEND_URL='$BACKEND_URL'"
+            exit 1
+          fi
+          
+          npx playwright install --with-deps chromium
+          # Pass DEPLOYED_URL explicitly to the test command
+          DEPLOYED_URL="$FINAL_URL" npx playwright test e2e/validate-deployment.spec.js --config e2e/playwright.config.js
+
+      - name: Handle Deployment Failure
+        if: failure() && (steps.validation.outcome == 'failure' || steps.health-check.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/handle-deployment-failure.sh
+          ./scripts/handle-deployment-failure.sh \
+            "${{ env.SERVICE }}" \
+            "${{ env.FRONTEND_SERVICE }}" \
+            "${{ env.REGION }}" \
+            "${{ steps.deploy-backend.outputs.url }}" \
+            "${{ github.sha }}"
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.DEPLOYED_URL || process.env.BASE_URL || 'http://localhost:8085',
+    baseURL: process.env.DEPLOYED_URL || process.env.BASE_URL || (process.env.CI ? undefined : 'http://localhost:8085'),
 
     /* Collect trace when retrying a failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',


### PR DESCRIPTION
## Description
The deployment validation failed because the Playwright tests were unable to determine the correct deployment URL, defaulting to `http://localhost:8085` in a CI environment where no local server was running.

This PR:
1.  **Restores the full deployment logic** to `.github/workflows/deploy.yml` which was previously truncated/paused.
2.  **Improves URL passing** to the Playwright tests in the post-deployment validation step by explicitly passing the `DEPLOYED_URL` as an environment variable to the test command.
3.  **Updates `e2e/playwright.config.js`** to avoid an accidental fallback to `localhost:8085` when running in CI, ensuring that missing configuration leads to a clearer failure.

These changes ensure that post-deployment validation runs against the actual Cloud Run service and that the CI pipeline is restored to its functional state.

Fixes #153

Generated by **Overseer** (powered by the gemini-3-flash-preview model).