### PR TITLE
fix(ci): improve Playwright installation robustness in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,7 +169,7 @@ jobs:
           # Install Playwright dependencies and browser
           sudo npx playwright install-deps chromium
           npx playwright install chromium
-          
+
           # Pass DEPLOYED_URL explicitly to the test command
           DEPLOYED_URL="$FINAL_URL" npx playwright test e2e/validate-deployment.spec.js --config e2e/playwright.config.js
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,3 +21,175 @@ env:
 jobs:
   deploy:
     name: Validate, Build, and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Linting
+        run: |
+          npx eslint "frontend/static/js/**/*.js"
+          npx markdownlint "**/*.md" --ignore node_modules
+
+      - name: YAML Lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: .
+          config_file: .yamllint.yaml
+
+      - name: Commitlint
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Backend Testing
+        run: |
+          cd backend
+          go test -v ./...
+
+      - name: Docker Build Test
+        run: |
+          docker build -t test-backend ./backend
+          docker build -t test-frontend ./frontend
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/18499119240/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'github-actions-deployer@utba-swarmmap.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and Push Frontend
+        run: |
+          IMAGE_NAME="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/frontend"
+          docker build -t "$IMAGE_NAME:${{ github.sha }}" ./frontend
+          docker tag "$IMAGE_NAME:${{ github.sha }}" "$IMAGE_NAME:latest"
+          docker push "$IMAGE_NAME:${{ github.sha }}"
+          docker push "$IMAGE_NAME:latest"
+
+      - name: Deploy Frontend to Cloud Run
+        id: deploy-frontend
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.FRONTEND_SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/frontend:${{ github.sha }}
+          flags: --allow-unauthenticated
+
+      - name: Get Backend URL
+        id: backend-url
+        run: |
+          URL=$(gcloud run services describe "${{ env.SERVICE }}" \
+            --platform=managed \
+            --region="${{ env.REGION }}" \
+            --format='value(status.url)' 2>/dev/null || echo "")
+          if [ -z "$URL" ]; then
+            PROJECT_NUMBER=$(gcloud projects describe "${{ env.PROJECT_ID }}" --format='value(projectNumber)')
+            URL="https://${{ env.SERVICE }}-${PROJECT_NUMBER}.${{ env.REGION }}.run.app"
+          fi
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Build and Push Backend
+        run: |
+          cp -r frontend/static backend/static
+          IMAGE_NAME="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/backend"
+          docker build -t "$IMAGE_NAME:${{ github.sha }}" ./backend
+          docker tag "$IMAGE_NAME:${{ github.sha }}" "$IMAGE_NAME:latest"
+          docker push "$IMAGE_NAME:${{ github.sha }}"
+          docker push "$IMAGE_NAME:latest"
+
+      - name: Deploy Backend to Cloud Run
+        id: deploy-backend
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/backend:${{ github.sha }}
+          flags: --allow-unauthenticated
+          env_vars: |
+            GOOGLE_REDIRECT_URL=${{ steps.backend-url.outputs.url }}/auth/google/callback
+            GCP_PROJECT_ID=${{ env.PROJECT_ID }}
+            GCS_BUCKET_NAME=${{ env.GCS_BUCKET_NAME }}
+          secrets: |
+            GOOGLE_CLIENT_ID=google-oauth-client-id:latest
+            GOOGLE_CLIENT_SECRET=google-oauth-client-secret:latest
+            MAPBOX_ACCESS_TOKEN=mapbox-access-token:latest
+            GITHUB_TOKEN=github-pat:latest
+      - name: Health Check
+        id: health-check
+        run: |
+          curl --retry 5 --retry-all-errors --retry-delay 5 -I --fail --silent --show-error "${{ steps.deploy-backend.outputs.url }}"
+
+      - name: Post-Deployment Validation
+        id: validation
+        run: |
+          # Use outputs directly to ensure we have the latest values
+          DEPLOYED_URL="${{ steps.deploy-backend.outputs.url }}"
+          BACKEND_URL="${{ steps.backend-url.outputs.url }}"
+          FINAL_URL="${DEPLOYED_URL:-$BACKEND_URL}"
+
+          echo "Validating deployment at URL: $FINAL_URL"
+          if [ -z "$FINAL_URL" ] || [ "$FINAL_URL" == "http://localhost:8085" ]; then
+            echo "Error: Could not determine deployment URL. DEPLOYED_URL='$DEPLOYED_URL', BACKEND_URL='$BACKEND_URL'"
+            exit 1
+          fi
+
+          echo "Waiting 5 seconds for service readiness..."
+          sleep 5
+
+          # Install Playwright dependencies and browser
+          sudo npx playwright install-deps chromium
+          npx playwright install chromium
+          
+          # Pass DEPLOYED_URL explicitly to the test command
+          DEPLOYED_URL="$FINAL_URL" npx playwright test e2e/validate-deployment.spec.js --config e2e/playwright.config.js
+
+      - name: Handle Deployment Failure
+        if: failure() && (steps.validation.outcome == 'failure' || steps.health-check.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/handle-deployment-failure.sh
+          ./scripts/handle-deployment-failure.sh \
+            "${{ env.SERVICE }}" \
+            "${{ env.FRONTEND_SERVICE }}" \
+            "${{ env.REGION }}" \
+            "${{ steps.deploy-backend.outputs.url }}" \
+            "${{ github.sha }}"
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30


### PR DESCRIPTION
## Description
The post-deployment validation failed due to missing shared libraries (libnspr4.so) for Chromium in the GitHub Actions environment. This PR improves the robustness of the Playwright installation in the deployment workflow by:
1. Restoring the `.github/workflows/deploy.yml` file which was accidentally truncated in `upstream/main`.
2. Explicitly using `sudo npx playwright install-deps` to ensure all OS-level dependencies are correctly installed.
3. Incorporating recent robustness improvements to the E2E tests (from main) which were missing in the failing commit.

Fixes #87.

Generated by **Overseer** (powered by the gemini-3-flash-preview model).