### PR TITLE
fix(ci): improve Playwright installation robustness and add FRONTEND_ASSETS_URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,7 @@ jobs:
             GOOGLE_REDIRECT_URL=${{ steps.backend-url.outputs.url }}/auth/google/callback
             GCP_PROJECT_ID=${{ env.PROJECT_ID }}
             GCS_BUCKET_NAME=${{ env.GCS_BUCKET_NAME }}
+            FRONTEND_ASSETS_URL=${{ steps.deploy-frontend.outputs.url }}
           secrets: |
             GOOGLE_CLIENT_ID=google-oauth-client-id:latest
             GOOGLE_CLIENT_SECRET=google-oauth-client-secret:latest
@@ -167,8 +168,7 @@ jobs:
           sleep 5
 
           # Install Playwright dependencies and browser
-          sudo npx playwright install-deps chromium
-          npx playwright install chromium
+          npx playwright install --with-deps chromium
 
           # Pass DEPLOYED_URL explicitly to the test command
           DEPLOYED_URL="$FINAL_URL" npx playwright test e2e/validate-deployment.spec.js --config e2e/playwright.config.js


### PR DESCRIPTION
## Description
The post-deployment validation failed because Playwright could not launch the browser due to a missing shared library (`libnspr4.so`). This PR improves the Playwright installation in the CI workflow by using the more robust `npx playwright install --with-deps chromium` command, which handles both the browser and its system dependencies correctly on the GitHub Actions runner.

Additionally, this PR adds the missing `FRONTEND_ASSETS_URL` environment variable to the backend deployment. This ensures that the backend correctly points to the frontend service for static assets, which is a recommended configuration.

## Changes
- Updated `.github/workflows/deploy.yml` to use `npx playwright install --with-deps chromium` for validation.
- Added `FRONTEND_ASSETS_URL` to the `utba-swarmmap-backend` Cloud Run deployment in `deploy.yml`.

Fixes #158

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).