### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   PROJECT_ID: utba-swarmmap
   REGION: northamerica-northeast2
   SERVICE: utba-swarmmap-backend

--- a/.github/workflows/e2e-startup.yaml
+++ b/.github/workflows/e2e-startup.yaml
@@ -2,6 +2,9 @@
 ---
 name: E2E Application Startup Check
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 "on":
   pull_request:
     branches: [main]
@@ -12,7 +15,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,6 +2,9 @@
 ---
 name: PR Checks
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 "on":
   push:
     branches: [main, issue-12-NPJh]
@@ -114,10 +117,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: frontend/go.mod
           cache-dependency-path: frontend/go.mod


### PR DESCRIPTION
This PR upgrades GitHub Actions to use Node.js 24 and resolves deprecation warnings by updating `actions/checkout` and `actions/setup-go` to v6, and adding the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to all workflows.

Fixes #159

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).