### PR TITLE
fix(backend): resolve deployment validation failure by reverting root routing to exact match

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -55,12 +55,6 @@ func (h *Handlers) IndexHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", "GET, HEAD")
-		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
 	session := h.getSession(r)
 
 	err := h.Templates.ExecuteTemplate(w, "index.html", map[string]interface{}{

--- a/backend/main.go
+++ b/backend/main.go
@@ -179,9 +179,8 @@ func main() {
 	}
 
 	// Public routes
-	// Root handler matches "/" exactly but also acts as a catch-all if needed.
-	// IndexHandler already contains logic to return 404 for unknown paths.
-	mux.HandleFunc("/", h.IndexHandler)
+	// Root handler matches "/" exactly. Go 1.22+ patterns with "GET" also match "HEAD".
+	mux.HandleFunc("GET /{$}", h.IndexHandler)
 	mux.HandleFunc("GET /get_swarms", h.GetSwarmsHandler)
 	mux.HandleFunc("GET /login", h.LoginPageHandler)
 	mux.HandleFunc("GET /register", h.RegisterPageHandler)


### PR DESCRIPTION
## Summary
The post-deployment validation failed because the backend returned HTTP 503 for `/api/track_visit`. This was likely caused by routing conflicts or unexpected behavior introduced by the catch-all root handler pattern (`/`) in Go 1.22.

This PR reverts the root handler to use the more specific and idiomatic Go 1.22 pattern `GET /{$}`. This pattern matches exact GET (and HEAD) requests to the root path, avoiding accidental hijacking of other routes or methods.

## Changes
- Updated `backend/main.go` to use `mux.HandleFunc("GET /{$}", h.IndexHandler)`.
- Updated `backend/handlers/handlers.go` to remove redundant method checks in `IndexHandler`.
- Maintained permissive `/static/` routing for HEAD request support.

Fixes #190

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).