### PR TITLE
Add build version and build date/time to pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,13 @@ jobs:
         run: |
           cp -r frontend/static backend/static
           IMAGE_NAME="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/backend"
-          docker build -t "$IMAGE_NAME:${{ github.sha }}" ./backend
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          VERSION="${{ github.ref_name }}-$SHORT_SHA"
+          docker build \
+            --build-arg BUILD_VERSION="$VERSION" \
+            --build-arg BUILD_DATE="$BUILD_DATE" \
+            -t "$IMAGE_NAME:${{ github.sha }}" ./backend
           docker tag "$IMAGE_NAME:${{ github.sha }}" "$IMAGE_NAME:latest"
           docker push "$IMAGE_NAME:${{ github.sha }}"
           docker push "$IMAGE_NAME:latest"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,9 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server .
+ARG BUILD_VERSION=unknown
+ARG BUILD_DATE=unknown
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'main.version=${BUILD_VERSION}' -X 'main.buildDate=${BUILD_DATE}'" -o /app/server .
 
 # STAGE 2: Create the final, minimal image
 FROM alpine:3.21.3

--- a/backend/handlers/admin.go
+++ b/backend/handlers/admin.go
@@ -79,6 +79,7 @@ func (h *Handlers) AdminHandler(w http.ResponseWriter, r *http.Request) {
 	err = h.Templates.ExecuteTemplate(w, "admin.html", map[string]interface{}{
 		"Title":             "Admin Dashboard",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"User":              session,
 		"PendingUsers":      pendingUsers,
 		"AllUsers":          allUsers,
@@ -118,6 +119,7 @@ func (h *Handlers) BootstrapHandler(w http.ResponseWriter, r *http.Request) {
 		err := h.Templates.ExecuteTemplate(w, "bootstrap.html", map[string]interface{}{
 			"Title":             "Bootstrap Admin",
 			"Version":           h.Version,
+			"BuildDate":         h.BuildDate,
 			"FrontendAssetsURL": h.FrontendAssetsURL,
 		})
 		if err != nil {
@@ -136,6 +138,7 @@ func (h *Handlers) BootstrapHandler(w http.ResponseWriter, r *http.Request) {
 		err := h.Templates.ExecuteTemplate(w, "bootstrap.html", map[string]interface{}{
 			"Title":             "Bootstrap Admin",
 			"Version":           h.Version,
+			"BuildDate":         h.BuildDate,
 			"Error":             "Name and Email are required",
 			"FrontendAssetsURL": h.FrontendAssetsURL,
 		})
@@ -166,6 +169,7 @@ func (h *Handlers) BootstrapHandler(w http.ResponseWriter, r *http.Request) {
 	err = h.Templates.ExecuteTemplate(w, "bootstrap.html", map[string]interface{}{
 		"Title":             "Bootstrap Admin",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"Success":           fmt.Sprintf("Administrator %s (%s) has been created successfully.", name, email),
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
@@ -309,6 +313,7 @@ func (h *Handlers) CollectorAdminHandler(w http.ResponseWriter, r *http.Request)
 	err = h.Templates.ExecuteTemplate(w, "collector_admin.html", map[string]interface{}{
 		"Title":             "Collector Admin",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"User":              session,
 		"PendingUsers":      pendingUsers,
 		"AllCollectors":     allCollectors,

--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -20,6 +20,7 @@ func (h *Handlers) LoginPageHandler(w http.ResponseWriter, _ *http.Request) {
 	err := h.Templates.ExecuteTemplate(w, "login.html", map[string]interface{}{
 		"Title":             "Login",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
 	if err != nil {
@@ -34,6 +35,7 @@ func (h *Handlers) RegisterPageHandler(w http.ResponseWriter, _ *http.Request) {
 	err := h.Templates.ExecuteTemplate(w, "register.html", map[string]interface{}{
 		"Title":             "Register",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
 	if err != nil {
@@ -254,6 +256,7 @@ func (h *Handlers) renderLoginPageWithError(w http.ResponseWriter, errorMsg stri
 	err := h.Templates.ExecuteTemplate(w, "login.html", map[string]interface{}{
 		"Title":             "Login",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"Error":             errorMsg,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
@@ -268,6 +271,7 @@ func (h *Handlers) renderRegisterPageWithError(w http.ResponseWriter, errorMsg s
 	err := h.Templates.ExecuteTemplate(w, "register.html", map[string]interface{}{
 		"Title":             "Register",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"Error":             errorMsg,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
@@ -283,6 +287,7 @@ func (h *Handlers) renderMessagePage(w http.ResponseWriter, title, message strin
 		"Title":             title,
 		"Message":           message,
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
 	if err != nil {
@@ -296,6 +301,7 @@ func (h *Handlers) showPendingApprovalPage(w http.ResponseWriter, name string) {
 	err := h.Templates.ExecuteTemplate(w, "pending-approval.html", map[string]interface{}{
 		"Name":              name,
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
 	if err != nil {
@@ -360,6 +366,7 @@ func (h *Handlers) ForgotPasswordHandler(w http.ResponseWriter, r *http.Request)
 		err := h.Templates.ExecuteTemplate(w, "forgot-password.html", map[string]interface{}{
 			"Title":             "Forgot Password",
 			"Version":           h.Version,
+			"BuildDate":         h.BuildDate,
 			"FrontendAssetsURL": h.FrontendAssetsURL,
 		})
 		if err != nil {
@@ -414,6 +421,7 @@ func (h *Handlers) ResetPasswordHandler(w http.ResponseWriter, r *http.Request) 
 		err := h.Templates.ExecuteTemplate(w, "reset-password.html", map[string]interface{}{
 			"Title":             "Reset Password",
 			"Version":           h.Version,
+			"BuildDate":         h.BuildDate,
 			"Token":             token,
 			"FrontendAssetsURL": h.FrontendAssetsURL,
 		})
@@ -446,6 +454,7 @@ func (h *Handlers) ResetPasswordHandler(w http.ResponseWriter, r *http.Request) 
 		err := h.Templates.ExecuteTemplate(w, "reset-password.html", map[string]interface{}{
 			"Title":             "Reset Password",
 			"Version":           h.Version,
+			"BuildDate":         h.BuildDate,
 			"Token":             token,
 			"Error":             "Password must be at least 8 characters long",
 			"FrontendAssetsURL": h.FrontendAssetsURL,

--- a/backend/handlers/dashboard.go
+++ b/backend/handlers/dashboard.go
@@ -42,6 +42,7 @@ func (h *Handlers) DashboardHandler(w http.ResponseWriter, r *http.Request) {
 	err = h.Templates.ExecuteTemplate(w, "dashboard.html", map[string]interface{}{
 		"Title":              "Dashboard",
 		"Version":            h.Version,
+		"BuildDate":          h.BuildDate,
 		"User":               session,
 		"AvailableSwarms":    availableSwarms,
 		"AssignedSwarms":     assignedSwarms,

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -28,6 +28,7 @@ type Handlers struct {
 	GoogleOAuthConfig *oauth2.Config
 	AppleOAuthConfig  *oauth2.Config
 	Version           string
+	BuildDate         string
 	Templates         *template.Template
 	FrontendAssetsURL string
 	MapboxToken       string
@@ -60,6 +61,7 @@ func (h *Handlers) IndexHandler(w http.ResponseWriter, r *http.Request) {
 	err := h.Templates.ExecuteTemplate(w, "index.html", map[string]interface{}{
 		"Title":             "Home",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"User":              session,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 		"MapboxToken":       h.MapboxToken,

--- a/backend/handlers/middleware.go
+++ b/backend/handlers/middleware.go
@@ -24,7 +24,7 @@ func (h *Handlers) SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		
+
 		// Only set HSTS if not on localhost
 		if !strings.HasPrefix(r.Host, "localhost") && !strings.HasPrefix(r.Host, "127.0.0.1") {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")

--- a/backend/handlers/views.go
+++ b/backend/handlers/views.go
@@ -28,6 +28,7 @@ func (h *Handlers) SwarmListHandler(w http.ResponseWriter, r *http.Request) {
 		"Title":             "Swarm List",
 		"Swarms":            swarms,
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"User":              session,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 	})
@@ -50,6 +51,7 @@ func (h *Handlers) CollectorsMapHandler(w http.ResponseWriter, r *http.Request) 
 	data := map[string]interface{}{
 		"Title":             "Collectors Map",
 		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
 		"User":              session,
 		"FrontendAssetsURL": h.FrontendAssetsURL,
 		"MapboxToken":       h.MapboxToken,

--- a/backend/main.go
+++ b/backend/main.go
@@ -23,7 +23,10 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-var version = "0.6.0"
+var (
+	version   = "0.6.0"
+	buildDate = "unknown"
+)
 
 // getEnv reads an environment variable with a fallback value.
 func getEnv(key, fallback string) string {
@@ -155,6 +158,7 @@ func main() {
 		AIService:         aiService,
 		GoogleOAuthConfig: googleOAuthConfig,
 		Version:           version,
+		BuildDate:         buildDate,
 		Templates:         templates,
 		FrontendAssetsURL: frontendAssetsURL,
 		MapboxToken:       mapboxToken,

--- a/backend/templates/footer.html
+++ b/backend/templates/footer.html
@@ -10,6 +10,9 @@
                 {{else}}
                     <a href="/login?role=site_admin" class="text-decoration-none">Site Admin Login</a>
                 {{end}}
+                <br>
+                {{if .Version}}<span class="opacity-75">v{{.Version}}</span>{{end}}
+                {{if .BuildDate}}<span class="opacity-75"> &bull; Built: {{.BuildDate}}</span>{{end}}
             </p>
         </div>
     </footer>


### PR DESCRIPTION
## Description
This PR adds the build version and build date/time to the bottom of all pages, near the footer. 

The version is derived from the GitHub branch/tag name and short commit SHA. The build date is the UTC timestamp of when the Docker image was built.

### Changes:
- Modified `backend/main.go` to include `version` and `buildDate` variables.
- Modified `backend/handlers/handlers.go` to include `BuildDate` in the `Handlers` struct.
- Updated all template handlers in `backend/handlers/` to pass `Version` and `BuildDate` to templates.
- Updated `backend/templates/footer.html` to display `Version` and `BuildDate`.
- Updated `backend/Dockerfile` to accept `BUILD_VERSION` and `BUILD_DATE` build arguments and set them via `-ldflags`.
- Updated `.github/workflows/deploy.yml` to pass these arguments during the build process.

Fixes #191

Generated by **Overseer** (powered by the gemini-3-flash-preview model).