### PR TITLE
fix: improve routing robustness to resolve deployment validation failure

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -48,9 +48,11 @@ func (h *Handlers) sanitize(s string) string {
 }
 
 func (h *Handlers) IndexHandler(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("IndexHandler called", "path", h.sanitize(r.URL.Path)) // #nosec G706
-	if r.URL.Path != "/" {
-		slog.Debug("Path not /, returning NotFound", "path", h.sanitize(r.URL.Path)) // #nosec G706
+	slog.Debug("IndexHandler called", "path", h.sanitize(r.URL.Path), "method", r.Method) // #nosec G706
+	
+	// Allow both "/" and "/index.html" for the home page
+	if r.URL.Path != "/" && r.URL.Path != "/index.html" {
+		slog.Debug("Path not recognized by IndexHandler, returning NotFound", "path", h.sanitize(r.URL.Path)) // #nosec G706
 		http.NotFound(w, r)
 		return
 	}
@@ -65,7 +67,7 @@ func (h *Handlers) IndexHandler(w http.ResponseWriter, r *http.Request) {
 		"MapboxToken":       h.MapboxToken,
 	})
 	if err != nil {
-		slog.Error("Error executing template", "error", err) // #nosec G706
+		slog.Error("Error executing template", "error", err, "path", h.sanitize(r.URL.Path)) // #nosec G706
 		http.Error(w, "Failed to render page", http.StatusInternalServerError)
 		return
 	}

--- a/backend/handlers/index_test.go
+++ b/backend/handlers/index_test.go
@@ -36,6 +36,22 @@ func TestIndexHandler(t *testing.T) {
 	}
 }
 
+func TestIndexHandler_IndexHtml(t *testing.T) {
+	mockStore := &MockStore{}
+	tmpl, _ := template.New("index.html").Parse("<html>Index</html>")
+	h := &Handlers{Store: mockStore, Templates: tmpl}
+
+	req, _ := http.NewRequest("GET", "/index.html", nil)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(h.IndexHandler)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code for /index.html: got %v want %v",
+			status, http.StatusOK)
+	}
+}
+
 func TestIndexHandler_NotFound(t *testing.T) {
 	h := &Handlers{}
 

--- a/backend/handlers/routing_test.go
+++ b/backend/handlers/routing_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Frank Currie (frank@sfle.ca)
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoutingMainConflict(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// Legacy pattern (no method)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	// New pattern (with method) - Exact match root
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("index"))
+	})
+
+	tests := []struct {
+		method string
+		path   string
+		status int
+		body   string
+	}{
+		{"GET", "/", http.StatusOK, "index"},
+		{"GET", "/healthz", http.StatusOK, "ok"},
+	}
+
+	for _, tt := range tests {
+		req := httptest.NewRequest(tt.method, tt.path, nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != tt.status {
+			t.Errorf("%s %s: expected status %d, got %d", tt.method, tt.path, tt.status, rr.Code)
+		}
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -175,8 +175,8 @@ func main() {
 	if _, err := os.Stat(staticDir); err == nil {
 		slog.Info("Serving static files", "dir", staticDir)
 		fs := http.FileServer(http.Dir(staticDir))
-		// Use a more permissive pattern for static files to support all methods (GET, HEAD, etc.)
-		mux.Handle("/static/", http.StripPrefix("/static/", fs))
+		// Use the GET prefix to avoid conflict with the catch-all root handler in Go 1.22+
+		mux.Handle("GET /static/", http.StripPrefix("/static/", fs))
 	} else {
 		slog.Warn("Static files directory not found, some assets may fail to load", "dir", staticDir)
 	}
@@ -191,8 +191,9 @@ func main() {
 	})
 
 	// Public routes
-	// Root handler matches "/" exactly. Go 1.22+ patterns with "GET" also match "HEAD".
-	mux.HandleFunc("GET /{$}", h.IndexHandler)
+	// Root handler matches "/" and acts as a catch-all for unknown GET requests.
+	// IndexHandler contains logic to return 404 for unknown sub-paths.
+	mux.HandleFunc("GET /", h.IndexHandler)
 	mux.HandleFunc("GET /get_swarms", h.GetSwarmsHandler)
 	mux.HandleFunc("GET /login", h.LoginPageHandler)
 	mux.HandleFunc("GET /register", h.RegisterPageHandler)


### PR DESCRIPTION
## Description
The post-deployment validation failed due to overly strict routing in the backend after the introduction of Go 1.22+ path patterns. This PR improves robustness by:
- Changing the root handler from an exact match ('GET /{$}') to a catch-all for GET requests ('GET /').
- Prefixing the static file handler with 'GET ' to avoid ambiguity/conflicts with the new catch-all root handler in the Go 1.22 mux.
- Explicitly supporting both '/' and '/index.html' in the IndexHandler.
- Improving logging for better observability of routing decisions.

These changes ensure that common requests (including those with unexpected paths or extensions like /index.html) are handled gracefully while maintaining the intended security and structure of the application.

Fixes #204

Generated by **Overseer** (powered by the gemini-3-flash-preview model).