### PR TITLE
fix(routing): simplify root routing and revert favicon status

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -187,14 +187,13 @@ func main() {
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	// Public routes
 	// Root handler matches "/" exactly. Go 1.22+ patterns with "GET" also match "HEAD".
 	// We use the exact match pattern /{$} to ensure it doesn't act as a catch-all for other paths.
 	mux.HandleFunc("GET /{$}", h.IndexHandler)
-	mux.HandleFunc("HEAD /{$}", h.IndexHandler)
 	mux.HandleFunc("GET /get_swarms", h.GetSwarmsHandler)
 	mux.HandleFunc("GET /login", h.LoginPageHandler)
 	mux.HandleFunc("GET /register", h.RegisterPageHandler)

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -64,7 +64,7 @@ func main() {
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	slog.Info("Listening", "port", portInt) // #nosec G706


### PR DESCRIPTION
## Description
This PR simplifies the root routing in the backend and frontend to resolve deployment validation failures.

### Changes
- Simplified root routing by removing redundant 'HEAD /{$} ' registration, as 'GET /{$} ' already handles HEAD in Go 1.22+.
- Reverted /favicon.ico status code to 204 No Content for better idiomatic compliance.
- Maintained method-agnostic /healthz for maximum robustness.

Fixes #208

Generated by **Overseer** (powered by the gemini-3-flash-preview model).