### PR TITLE
feat: remove redundant map legend from home page

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -30,37 +30,6 @@
             </div>
         </div>
 
-        <aside class="col-lg-12 mb-5">
-            <div class="text-center mb-3">
-                <h2 id="legendTitle" class="h6 fw-bold text-uppercase tracking-wider text-muted">
-                    <i class="fa-solid fa-circle-info me-2 text-warning"></i>Map Legend
-                </h2>
-            </div>
-            <div class="col-md-12">
-                <div class="d-flex flex-wrap justify-content-center gap-3" role="list">
-                    <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(232, 65, 24);" aria-hidden="true"></span>
-                        <span class="small fw-bold text-uppercase tracking-wider">Reported</span>
-                    </div>
-                    <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(251, 197, 49);" aria-hidden="true"></span>
-                        <span class="small fw-bold text-uppercase tracking-wider">Verified</span>
-                    </div>
-                    <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(255, 140, 0);" aria-hidden="true"></span>
-                        <span class="small fw-bold text-uppercase tracking-wider">Claimed</span>
-                    </div>
-                    <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(76, 209, 55);" aria-hidden="true"></span>
-                        <span class="small fw-bold text-uppercase tracking-wider">Captured</span>
-                    </div>
-                    <div class="legend-item d-flex align-items-center" role="listitem">
-                        <span class="legend-color" style="background-color: rgb(72, 126, 176);" aria-hidden="true"></span>
-                        <span class="small fw-bold text-uppercase tracking-wider">Archived</span>
-                    </div>
-                </div>
-            </div>
-        </aside>
     </div>
 
     <!-- Report Swarm Modal -->
@@ -146,21 +115,6 @@
 </div>
 
 <style>
-    .legend-color {
-        width: 14px;
-        height: 14px;
-        border-radius: 4px;
-        margin-right: 8px;
-        display: inline-block;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    }
-    
-    .legend-item {
-        padding: 6px 12px;
-        border-radius: 8px;
-        background-color: #f8f9fa;
-    }
-
     /* Custom popup styling */
     .mapboxgl-popup-content {
         padding: 0;

--- a/e2e/validate-deployment.spec.js
+++ b/e2e/validate-deployment.spec.js
@@ -181,48 +181,6 @@ test('deployment validation - basic elements and assets', async ({
     `Map height should be at least 350px, but got ${mapHeight}`,
   ).toBeGreaterThanOrEqual(350);
 
-  const legend = page.locator('#legendTitle');
-  await expect(legend).toBeVisible({ timeout: 15000 });
-  await expect(legend).toHaveText(/Map Legend/i);
-  await expect(legend.locator('i.fa-circle-info')).toBeAttached();
-
-  // Check legend items specifically within the aside area for robustness
-  console.log('Verifying legend items...');
-  const legendItems = page.locator('aside .legend-item');
-  await expect(legendItems).toHaveCount(5);
-
-  // Verify specific legend text and colors for robustness
-  const expectedLegend = [
-    { text: /Reported/i, color: 'rgb(232, 65, 24)' }, // #e84118
-    { text: /Verified/i, color: 'rgb(251, 197, 49)' }, // #fbc531
-    { text: /Claimed/i, color: 'rgb(255, 140, 0)' }, // #ff8c00
-    { text: /Captured/i, color: 'rgb(76, 209, 55)' }, // #4cd137
-    { text: /Archived/i, color: 'rgb(72, 126, 176)' }, // #487eb0
-  ];
-
-  for (let i = 0; i < expectedLegend.length; i++) {
-    const item = legendItems.nth(i);
-    await expect(item).toContainText(expectedLegend[i].text);
-    const colorSpan = item.locator('.legend-color');
-    await expect(colorSpan).toBeVisible();
-
-    // Use normalized color comparison to handle browser spacing differences in rgb strings
-    const actualColor = await colorSpan.evaluate(
-      (el) => window.getComputedStyle(el).backgroundColor,
-    );
-    const normalize = (c) => {
-      if (!c) return '';
-      // Remove spaces and lowercase
-      let n = c.replace(/\s+/g, '').toLowerCase();
-      // Handle rgba(r,g,b,1) -> rgb(r,g,b)
-      return n.replace(/rgba\((\d+,\d+,\d+),1\)/, 'rgb($1)');
-    };
-    expect(
-      normalize(actualColor),
-      `Legend item ${i} (${expectedLegend[i].text}) has wrong color (Actual: ${actualColor})`,
-    ).toBe(normalize(expectedLegend[i].color));
-  }
-
   const footer = page.locator('footer');
   await expect(footer).toBeVisible();
   await expect(footer).toContainText(/Made by .* in Toronto Canada/i);


### PR DESCRIPTION
# Description

The legend on the report swarm map (home page) is redundant as it is only needed for the Swarm Collectors map. This PR removes the legend from the home page and updates the associated E2E tests to reflect this change.

## Key Changes

- **Templates:**
  - Removed the `Map Legend` section from `backend/templates/index.html`.
  - Removed the associated CSS styles for the legend from `backend/templates/index.html`.
- **E2E Tests:**
  - Updated `e2e/validate-deployment.spec.js` to remove the checks for the legend on the home page.

Fixes #221

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).