### PR TITLE
Add About page with monthly grouped features and bug fixes

### DIFF
--- a/backend/handlers/about.go
+++ b/backend/handlers/about.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Frank Currie (frank@sfle.ca)
+
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+	"sort"
+)
+
+type MonthGroup struct {
+	Month    string
+	Features []GitHubIssue
+	Bugs     []GitHubIssue
+}
+
+func (h *Handlers) AboutHandler(w http.ResponseWriter, r *http.Request) {
+	session := h.getSession(r)
+	
+	issues, err := h.GitHubService.GetClosedIssues(h.GithubRepo, h.GithubToken)
+	if err != nil {
+		slog.Error("Failed to fetch closed issues", "error", err)
+		// Fallback to empty list or error page
+		issues = []GitHubIssue{}
+	}
+
+	groups := make(map[string]*MonthGroup)
+	var monthKeys []string
+
+	for _, issue := range issues {
+		// GitHub Issues API returns both issues and pull requests.
+		// We only want issues.
+		if issue.PullRequest != nil {
+			continue
+		}
+
+		// Use ClosedAt if available, otherwise CreatedAt
+		date := issue.ClosedAt
+		if date.IsZero() {
+			date = issue.CreatedAt
+		}
+		
+		monthKey := date.Format("2006-01")
+		if _, ok := groups[monthKey]; !ok {
+			groups[monthKey] = &MonthGroup{
+				Month: date.Format("January 2006"),
+			}
+			monthKeys = append(monthKeys, monthKey)
+		}
+
+		isBug := false
+		isFeature := false
+		for _, label := range issue.Labels {
+			if label.Name == "bug" {
+				isBug = true
+			}
+			if label.Name == "enhancement" {
+				isFeature = true
+			}
+		}
+
+		if isBug {
+			groups[monthKey].Bugs = append(groups[monthKey].Bugs, issue)
+		} else if isFeature {
+			groups[monthKey].Features = append(groups[monthKey].Features, issue)
+		}
+	}
+
+	// Sort months descending
+	sort.Sort(sort.Reverse(sort.StringSlice(monthKeys)))
+
+	var sortedGroups []*MonthGroup
+	for _, key := range monthKeys {
+		sortedGroups = append(sortedGroups, groups[key])
+	}
+
+	data := map[string]interface{}{
+		"Title":             "About",
+		"Version":           h.Version,
+		"BuildDate":         h.BuildDate,
+		"User":              session,
+		"FrontendAssetsURL": h.FrontendAssetsURL,
+		"Groups":            sortedGroups,
+	}
+
+	err = h.Templates.ExecuteTemplate(w, "about.html", data)
+	if err != nil {
+		slog.Error("Error executing about template", "error", err)
+		http.Error(w, "Failed to render about page", http.StatusInternalServerError)
+		return
+	}
+}

--- a/backend/handlers/about_test.go
+++ b/backend/handlers/about_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Frank Currie (frank@sfle.ca)
+
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAboutHandler(t *testing.T) {
+	now := time.Now()
+	mockGitHub := &MockGitHubService{
+		ReturnIssues: []GitHubIssue{
+			{
+				Title: "New Feature",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{
+					{Name: "enhancement"},
+				},
+				CreatedAt: now,
+			},
+			{
+				Title: "Bug Fix",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{
+					{Name: "bug"},
+				},
+				CreatedAt: now,
+			},
+			{
+				Title: "Ignored PR",
+				PullRequest: map[string]interface{}{"url": "http://example.com"},
+				Labels: []struct {
+					Name string `json:"name"`
+				}{
+					{Name: "enhancement"},
+				},
+				CreatedAt: now,
+			},
+		},
+	}
+	
+	// Create a template with both about.html and header.html/footer.html if needed, 
+	// but for this test, a simple template named about.html is enough as we are 
+	// only testing the handler logic and execution of the main template.
+	tmpl, err := template.New("about.html").Parse("<html>{{.Title}} - {{len .Groups}} groups</html>")
+	if err != nil {
+		t.Fatalf("Error parsing template: %v", err)
+	}
+
+	h := &Handlers{
+		GitHubService: mockGitHub,
+		Templates:     tmpl,
+	}
+
+	req, err := http.NewRequest("GET", "/about", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.AboutHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+	
+	expected := "About - 1 groups"
+	if !contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}
+
+func contains(s, substr string) bool {
+	return (s != "" && substr != "" && (len(s) >= len(substr)) && (s[0:len(substr)] == substr || contains(s[1:], substr)))
+}

--- a/backend/handlers/feedback.go
+++ b/backend/handlers/feedback.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"cloud.google.com/go/vertexai/genai"
 )
@@ -90,14 +91,59 @@ Maintain a professional and constructive tone. Do not include any other text tha
 	return interpreted, nil
 }
 
+// GitHubIssue represents a GitHub issue.
+type GitHubIssue struct {
+	Title       string    `json:"title"`
+	Body        string    `json:"body"`
+	State       string    `json:"state"`
+	CreatedAt   time.Time `json:"created_at"`
+	ClosedAt    time.Time `json:"closed_at"`
+	PullRequest interface{} `json:"pull_request,omitempty"`
+	Labels      []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
 // GitHubService defines the interface for GitHub operations.
 type GitHubService interface {
 	CreateIssue(repo, token, title, body string, labels []string) error
+	GetClosedIssues(repo, token string) ([]GitHubIssue, error)
 }
 
 // RealGitHubService implements GitHubService using the GitHub API.
 type RealGitHubService struct {
 	Client *http.Client
+}
+
+func (s *RealGitHubService) GetClosedIssues(repo, token string) ([]GitHubIssue, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/issues?state=closed&per_page=100", repo)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub request: %w", err)
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send GitHub request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned non-200 status: %d", resp.StatusCode)
+	}
+
+	var issues []GitHubIssue
+	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
+		return nil, fmt.Errorf("failed to decode GitHub issues: %w", err)
+	}
+
+	return issues, nil
 }
 
 func (s *RealGitHubService) CreateIssue(repo, token, title, body string, labels []string) error {

--- a/backend/handlers/feedback_test.go
+++ b/backend/handlers/feedback_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 type MockGitHubService struct {
-	LastRepo   string
-	LastToken  string
-	LastTitle  string
-	LastBody   string
-	LastLabels []string
-	ReturnErr  error
+	LastRepo     string
+	LastToken    string
+	LastTitle    string
+	LastBody     string
+	LastLabels   []string
+	ReturnErr    error
+	ReturnIssues []GitHubIssue
 }
 
 func (m *MockGitHubService) CreateIssue(repo, token, title, body string, labels []string) error {
@@ -28,6 +29,12 @@ func (m *MockGitHubService) CreateIssue(repo, token, title, body string, labels 
 	m.LastBody = body
 	m.LastLabels = labels
 	return m.ReturnErr
+}
+
+func (m *MockGitHubService) GetClosedIssues(repo, token string) ([]GitHubIssue, error) {
+	m.LastRepo = repo
+	m.LastToken = token
+	return m.ReturnIssues, m.ReturnErr
 }
 
 type MockAIService struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -202,6 +202,7 @@ func main() {
 	// Root handler matches "/" exactly. Go 1.22+ patterns with "GET" also match "HEAD".
 	// We use the exact match pattern /{$} to ensure it doesn't act as a catch-all for other paths.
 	mux.HandleFunc("GET /{$}", h.IndexHandler)
+	mux.HandleFunc("GET /about", h.AboutHandler)
 	mux.HandleFunc("GET /get_swarms", h.GetSwarmsHandler)
 	mux.HandleFunc("GET /login", h.LoginPageHandler)
 	mux.HandleFunc("GET /register", h.RegisterPageHandler)

--- a/backend/templates/about.html
+++ b/backend/templates/about.html
@@ -1,0 +1,77 @@
+<!-- Copyright (c) 2026 Frank Currie (frank@sfle.ca) -->
+{{template "header.html" .}}
+
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-10">
+            <div class="text-center mb-5">
+                <h1 class="display-4 fw-800 mb-3">What's New</h1>
+                <p class="lead text-muted">Tracking the latest features and bug fixes on the UTBA Swarm Map.</p>
+            </div>
+
+            {{if .Groups}}
+                {{range .Groups}}
+                    <div class="mb-5">
+                        <div class="d-flex align-items-center mb-4">
+                            <h2 class="h3 fw-bold mb-0">{{.Month}}</h2>
+                            <div class="flex-grow-1 ms-3 border-bottom"></div>
+                        </div>
+                        
+                        <div class="row">
+                            {{if .Features}}
+                                <div class="col-md-6 mb-4">
+                                    <h3 class="h5 text-primary fw-bold mb-3">
+                                        <i class="fa-solid fa-wand-magic-sparkles me-2"></i> Features
+                                    </h3>
+                                    <div class="list-group list-group-flush shadow-sm rounded border">
+                                        {{range .Features}}
+                                            <div class="list-group-item py-3">
+                                                <div class="fw-bold text-dark">{{.Title}}</div>
+                                            </div>
+                                        {{/range}}
+                                    </div>
+                                </div>
+                            {{end}}
+
+                            {{if .Bugs}}
+                                <div class="col-md-6 mb-4">
+                                    <h3 class="h5 text-warning fw-bold mb-3">
+                                        <i class="fa-solid fa-bug me-2"></i> Bug Fixes
+                                    </h3>
+                                    <div class="list-group list-group-flush shadow-sm rounded border">
+                                        {{range .Bugs}}
+                                            <div class="list-group-item py-3">
+                                                <div class="fw-bold text-dark">{{.Title}}</div>
+                                            </div>
+                                        {{/range}}
+                                    </div>
+                                </div>
+                            {{end}}
+                        </div>
+                    </div>
+                {{end}}
+            {{else}}
+                <div class="text-center py-5 bg-light rounded-4 border border-dashed">
+                    <i class="fa-solid fa-clock-rotate-left fa-3x text-muted opacity-25 mb-3"></i>
+                    <p class="text-muted mb-0">No updates found yet. We're constantly working on improvements!</p>
+                </div>
+            {{end}}
+
+            <div class="mt-5 pt-5 border-top text-center">
+                <p class="text-muted small">
+                    This information is live-synced from our <a href="https://github.com/fkcurrie/utba-swarmmap/issues" target="_blank" class="text-decoration-none">GitHub repository</a>.
+                </p>
+                <a href="/" class="btn btn-outline-secondary btn-sm mt-3">
+                    <i class="fa-solid fa-arrow-left me-1"></i> Back to Map
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .fw-800 { font-weight: 800; }
+    .border-dashed { border-style: dashed !important; }
+</style>
+
+{{template "footer.html" .}}

--- a/backend/templates/header.html
+++ b/backend/templates/header.html
@@ -32,6 +32,11 @@
                 <div class="collapse navbar-collapse" id="navbarNav">
                     <ul class="navbar-nav ms-auto align-items-center gap-2">
                         <li class="nav-item">
+                            <a class="nav-link px-3" href="/about">
+                                <i class="fa-solid fa-circle-info me-1"></i> About
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <button type="button" class="btn btn-sm btn-link nav-link px-3" data-bs-toggle="modal" data-bs-target="#feedbackModal">
                                 <i class="fa-solid fa-comment-dots me-1"></i> Give Feedback
                             </button>


### PR DESCRIPTION
This PR adds a new 'About' page that fetches closed issues from GitHub, groups them by month, and displays them as features and bug fixes. An 'About' link is added to the header.

Fixes #222

Generated by **Overseer** (powered by the gemini-3-flash-preview model).